### PR TITLE
fix: prevent word bank dropdown from overflowing viewport

### DIFF
--- a/public/modules/fib.css
+++ b/public/modules/fib.css
@@ -185,7 +185,9 @@
   width: max-content;
   min-width: 220px;
   max-width: min(600px, calc(100vw - 40px));
-  
+  max-height: min(320px, 60vh);
+  overflow-y: auto;
+
   display: flex;
   flex-direction: column;
 

--- a/public/modules/fib.css
+++ b/public/modules/fib.css
@@ -187,6 +187,7 @@
   max-width: min(600px, calc(100vw - 40px));
   max-height: min(320px, 60vh);
   overflow-y: auto;
+  overscroll-behavior: contain;
 
   display: flex;
   flex-direction: column;

--- a/public/modules/fib.js
+++ b/public/modules/fib.js
@@ -127,6 +127,12 @@ export function initFib({
     });
   }
 
+  function handleOutsideScroll(e) {
+    if (!openDropdown) return;
+    if (openDropdown.container.contains(e.target)) return;
+    closeMenu();
+  }
+
   function closeMenu() {
     if (!openDropdown) return;
     const { container, blank } = openDropdown;
@@ -135,7 +141,7 @@ export function initFib({
     blank.classList.remove('dropdown-open');
     document.removeEventListener('mousedown', handleOutside);
     window.removeEventListener('resize', closeMenu);
-    window.removeEventListener('scroll', closeMenu, true);
+    window.removeEventListener('scroll', handleOutsideScroll, true);
     openDropdown = null;
   }
 
@@ -192,7 +198,7 @@ export function initFib({
     const docY = rect.bottom + window.scrollY + 4;
     menu.style.left = docX + 'px';
     menu.style.top = docY + 'px';
-    
+
     // Add class to blank to keep hover effect active
     blank.classList.add('dropdown-open');
 
@@ -215,6 +221,17 @@ export function initFib({
     });
 
     document.body.appendChild(menu);
+
+    // Smart positioning: flip upward if dropdown overflows the viewport bottom
+    const menuRect = menu.getBoundingClientRect();
+    if (menuRect.bottom > window.innerHeight - 8) {
+      const spaceAbove = rect.top - 4;
+      const menuHeight = menu.offsetHeight;
+      if (spaceAbove >= menuHeight || spaceAbove > menuRect.bottom - window.innerHeight) {
+        menu.style.top = (rect.top + window.scrollY - menuHeight - 4) + 'px';
+      }
+    }
+
     blank.setAttribute('aria-expanded', 'true');
     openDropdown = { container: menu, blank, idx };
     
@@ -229,7 +246,7 @@ export function initFib({
     
     document.addEventListener('mousedown', handleOutside);
     window.addEventListener('resize', closeMenu);
-    window.addEventListener('scroll', closeMenu, true);
+    window.addEventListener('scroll', handleOutsideScroll, true);
   }
 
   function setSelection(idx, choice) {

--- a/public/modules/fib.js
+++ b/public/modules/fib.js
@@ -223,12 +223,19 @@ export function initFib({
     document.body.appendChild(menu);
 
     // Smart positioning: flip upward if dropdown overflows the viewport bottom
-    const menuRect = menu.getBoundingClientRect();
-    if (menuRect.bottom > window.innerHeight - 8) {
-      const spaceAbove = rect.top - 4;
-      const menuHeight = menu.offsetHeight;
-      if (spaceAbove >= menuHeight || spaceAbove > menuRect.bottom - window.innerHeight) {
-        menu.style.top = (rect.top + window.scrollY - menuHeight - 4) + 'px';
+    const viewportPadding = 8;
+    const gap = 4;
+    const menuHeight = menu.offsetHeight;
+    const spaceAbove = rect.top - viewportPadding - gap;
+    const spaceBelow = window.innerHeight - rect.bottom - viewportPadding - gap;
+
+    if (spaceBelow < menuHeight) {
+      if (spaceAbove > spaceBelow) {
+        const clampedHeight = Math.min(menuHeight, spaceAbove);
+        menu.style.maxHeight = `${clampedHeight}px`;
+        menu.style.top = `${rect.top + window.scrollY - clampedHeight - gap}px`;
+      } else {
+        menu.style.maxHeight = `${Math.max(spaceBelow, 0)}px`;
       }
     }
 


### PR DESCRIPTION
## Summary
- Add `max-height` + `overflow-y: auto` to `.fib-dropdown` so options scroll internally when the word bank is large
- Flip the dropdown above the blank when there is insufficient space below the viewport
- Fix a bug where the scroll listener was closing the menu when the user scrolled inside the dropdown itself

Closes #4

## Fix in action

https://github.com/user-attachments/assets/59e6817d-ae19-4e50-8fb8-91dd1b661e54


## Test plan
- [ ] Open a FIB activity with 6+ word bank options
- [ ] Click a blank near the bottom of the screen — dropdown should flip upward
- [ ] Scroll inside the dropdown — it should stay open
- [ ] Click outside or scroll the page — dropdown should close normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)