### PR TITLE
Support Markdown tables across activity renderers

### DIFF
--- a/data/examples/fib-markdown-table-inline-blanks.md
+++ b/data/examples/fib-markdown-table-inline-blanks.md
@@ -1,0 +1,23 @@
+__Type__
+
+Fill In The Blanks
+
+__Heading__
+
+Complete the missing cells in the table.
+
+__Markdown With Blanks__
+
+Fill in each capital directly in the table.
+
+> | Country | Capital |
+> | --- | --- |
+> | France | [[blank:Paris]] |
+> | Japan | [[blank:Tokyo]] |
+> | Brazil | [[blank:Brasília]] |
+
+__Suggested Answers__
+
+- Paris
+- Tokyo
+- Brasília

--- a/data/examples/fib-markdown-table-reference.md
+++ b/data/examples/fib-markdown-table-reference.md
@@ -1,0 +1,27 @@
+__Type__
+
+Fill In The Blanks
+
+__Heading__
+
+Complete the missing capitals using the reference table.
+
+__Markdown With Blanks__
+
+Use the table to answer the prompts.
+
+> | Country | Capital |
+> | --- | --- |
+> | France | Paris |
+> | Japan | Tokyo |
+> | Brazil | Brasília |
+>
+> 1. The capital of France is [[blank:Paris]].
+> 2. The capital of Japan is [[blank:Tokyo]].
+> 3. The capital of Brazil is [[blank:Brasília]].
+
+__Suggested Answers__
+
+- Paris
+- Tokyo
+- Brasília

--- a/data/examples/matrix-markdown-table.md
+++ b/data/examples/matrix-markdown-table.md
@@ -1,0 +1,30 @@
+__Type__
+
+Matrix
+
+__Practice Question__
+
+Review the score table before selecting a recommendation for each student.
+
+| Student | Score |
+| --- | --- |
+| Ada | 92 |
+| Ben | 74 |
+| Cora | 88 |
+
+__Matrix Columns__
+
+- Recommend tutoring
+- No tutoring needed
+
+__Matrix Rows__
+
+- Ada
+- Ben
+- Cora
+
+__Suggested Answers__
+
+- Ada: No tutoring needed
+- Ben: Recommend tutoring
+- Cora: No tutoring needed

--- a/data/examples/mcq-markdown-table.md
+++ b/data/examples/mcq-markdown-table.md
@@ -1,0 +1,27 @@
+__Type__
+
+Multiple Choice
+
+__Practice Question__
+
+Study the table, then pick the correct answer.
+
+| Animal | Class | Warm-blooded |
+| --- | --- | --- |
+| Dolphin | Mammal | Yes |
+| Eagle | Bird | Yes |
+| Lizard | Reptile | No |
+
+Which animal in the table is a reptile?
+
+A. Dolphin  
+B. Eagle  
+C. Lizard  
+D. All of them
+
+__Suggested Answers__
+
+- A
+- B
+- C - Correct
+- D

--- a/data/examples/side-content-markdown-table.md
+++ b/data/examples/side-content-markdown-table.md
@@ -1,0 +1,25 @@
+__Type__
+
+Text Input
+
+__Content__
+
+# Reference Table
+
+| Language | Country |
+| --- | --- |
+| Portuguese | Brazil |
+| Japanese | Japan |
+| French | France |
+
+Use the table in the side panel to answer the question.
+
+[contentWidth: 35%]
+
+__Practice Question__
+
+Which country in the side panel is associated with Portuguese?
+
+__Correct Answers__
+
+- Brazil [kind: string] [options: caseSensitive=false]

--- a/data/examples/text-input-markdown-table.md
+++ b/data/examples/text-input-markdown-table.md
@@ -1,0 +1,19 @@
+__Type__
+
+Text Input
+
+__Practice Question__
+
+Use the table as reference before answering.
+
+| Planet | Type | Moons |
+| --- | --- | --- |
+| Earth | Rocky | 1 |
+| Jupiter | Gas giant | 95 |
+| Neptune | Ice giant | 16 |
+
+Which planet in the table is an ice giant?
+
+__Correct Answers__
+
+- Neptune [kind: string] [options: caseSensitive=false]

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="/design-system/components/button/button.css" />
   <link rel="stylesheet" href="/design-system/components/tags/tags.css" />
   <link rel="stylesheet" href="/design-system/components/icons/icons.css" />
+  <link rel="stylesheet" href="/design-system/components/table/table.css" />
   <link rel="stylesheet" href="/components/toolbar.css" />
   <link rel="stylesheet" href="/styles.css" />
   <link rel="stylesheet" href="/activity-content-shell.css" />
@@ -44,5 +45,4 @@
   <script type="module" src="/app.js"></script>
 </body>
 </html>
-
 

--- a/public/modules/fib.js
+++ b/public/modules/fib.js
@@ -28,7 +28,7 @@ export function initFib({
   if (fibInstr && (fibInstr.html || fibInstr.markdown)) {
     const instrEl = document.createElement('div');
     instrEl.className =
-      'text-input-heading box non-interactive input-group text-input-question-text body-large';
+      'text-input-heading box non-interactive input-group text-input-question-text body-large markdown-content';
     if (fibInstr.html) {
       instrEl.innerHTML = fibInstr.html;
     } else {
@@ -43,26 +43,22 @@ export function initFib({
     elFibHeading.textContent = 'Fill in the blanks';
   }
 
+  elFibContent.classList.add('markdown-content');
+
   // Content HTML is provided by server with embedded blank spans
   elFibContent.innerHTML = fib.htmlWithPlaceholders;
   // Render LaTeX math expressions
   renderMath(elFibContent);
 
-  // Wrap each question (p containing a blank) in div.fib-question
-  const questionParagraphs = Array.from(elFibContent.querySelectorAll('p')).filter((p) => p.querySelector('.blank'));
-  const wrappers = [];
+  // Wrap each top-level block that contains blanks so tables/lists survive intact.
   const questionStyleClass = fib.questionStyle ? ' ' + String(fib.questionStyle).trim() : '';
-  questionParagraphs.forEach((p) => {
+  const questionBlocks = Array.from(elFibContent.children).filter((el) => el.querySelector('.blank'));
+  questionBlocks.forEach((block) => {
     const wrapper = document.createElement('div');
     wrapper.className = 'fib-question' + questionStyleClass;
-    p.parentNode.insertBefore(wrapper, p);
-    wrapper.appendChild(p);
-    wrappers.push(wrapper);
+    block.parentNode.insertBefore(wrapper, block);
+    wrapper.appendChild(block);
   });
-  while (elFibContent.firstChild) {
-    elFibContent.removeChild(elFibContent.firstChild);
-  }
-  wrappers.forEach((w) => elFibContent.appendChild(w));
 
   // Build dropdowns in each blank and synchronize options across all blanks
   const blanks = Array.from(elFibContent.querySelectorAll('.blank')).sort((a, b) => {

--- a/public/modules/matrix.js
+++ b/public/modules/matrix.js
@@ -67,7 +67,7 @@ export function initMatrix({
   if (matrixHeading && (matrixHeading.html || matrixHeading.markdown)) {
     const headingEl = document.createElement('div');
     headingEl.className =
-      'text-input-heading box non-interactive input-group text-input-question-text body-large';
+      'text-input-heading box non-interactive input-group text-input-question-text body-large markdown-content';
     if (matrixHeading.html) {
       headingEl.innerHTML = matrixHeading.html;
     } else {
@@ -78,6 +78,7 @@ export function initMatrix({
   }
 
   if (activity.questionHtml) {
+    elQuestion.classList.add('markdown-content');
     elQuestion.innerHTML = activity.questionHtml;
     renderMath(elQuestion);
   } else if (activity.question) {

--- a/public/modules/mcq.js
+++ b/public/modules/mcq.js
@@ -119,7 +119,7 @@ export function initMcq({
       input.id = `q${question.id}-opt${optIdx}`;
       input.setAttribute('aria-label', `Option ${option.label}: ${option.text}`);
       
-      const optionText = document.createElement('span');
+      const optionText = document.createElement('div');
       optionText.className = 'mcq-option-text body-large markdown-content';
       // Support markdown HTML if available, fallback to plain text for backward compatibility
       if (option.textHtml) {

--- a/public/modules/mcq.js
+++ b/public/modules/mcq.js
@@ -34,7 +34,7 @@ export function initMcq({
   if (hasHeading) {
     const headingEl = document.createElement('div');
     headingEl.className =
-      'text-input-heading box non-interactive input-group text-input-question-text body-large';
+      'text-input-heading box non-interactive input-group text-input-question-text body-large markdown-content';
     if (mcq.heading.html) {
       headingEl.innerHTML = mcq.heading.html;
     } else {
@@ -90,7 +90,7 @@ export function initMcq({
     
     // Question text (support markdown HTML if available, fallback to plain text for backward compatibility)
     const questionTextEl = document.createElement('div');
-    questionTextEl.className = 'mcq-question-text body-large';
+    questionTextEl.className = 'mcq-question-text body-large markdown-content';
     if (question.textHtml) {
       questionTextEl.innerHTML = question.textHtml;
       // Render LaTeX math expressions
@@ -120,7 +120,7 @@ export function initMcq({
       input.setAttribute('aria-label', `Option ${option.label}: ${option.text}`);
       
       const optionText = document.createElement('span');
-      optionText.className = 'mcq-option-text body-large';
+      optionText.className = 'mcq-option-text body-large markdown-content';
       // Support markdown HTML if available, fallback to plain text for backward compatibility
       if (option.textHtml) {
         optionText.innerHTML = option.textHtml;
@@ -509,4 +509,3 @@ export function initMcq({
     validate: validateAnswers
   };
 }
-

--- a/public/modules/text-input.js
+++ b/public/modules/text-input.js
@@ -259,7 +259,7 @@ export function initTextInput({
   const hasHeading = textInput.heading && (textInput.heading.html || textInput.heading.markdown);
   if (hasHeading) {
     const headingEl = document.createElement('div');
-    headingEl.className = 'text-input-heading box non-interactive input-group text-input-question-text body-large';
+    headingEl.className = 'text-input-heading box non-interactive input-group text-input-question-text body-large markdown-content';
     if (textInput.heading.html) {
       headingEl.innerHTML = textInput.heading.html;
     } else {
@@ -293,7 +293,7 @@ export function initTextInput({
     
     // Question text (support markdown HTML if available, fallback to plain text)
     const questionTextEl = document.createElement('div');
-    questionTextEl.className = 'text-input-question-text body-large';
+    questionTextEl.className = 'text-input-question-text body-large markdown-content';
     if (question.textHtml) {
       questionTextEl.innerHTML = question.textHtml;
       // Render LaTeX math expressions

--- a/public/styles.css
+++ b/public/styles.css
@@ -160,62 +160,6 @@ blockquote + p,  blockquote + h1, blockquote + h2, blockquote + h3, blockquote +
   max-width: 100%;
 }
 
-.markdown-content table {
-  display: block;
-  width: fit-content;
-  min-width: 0;
-  max-width: 100%;
-  overflow-x: auto;
-  border-collapse: collapse;
-  margin: 1em 0;
-  background: var(--Colors-Backgrounds-Main-Top);
-  border: 1px solid var(--Colors-Stroke-Default);
-  border-radius: var(--UI-Radius-radius-s, 8px);
-}
-
-.markdown-content thead {
-  background: var(--Colors-Backgrounds-Main-Medium);
-}
-
-.markdown-content tbody {
-  background: var(--Colors-Backgrounds-Main-Top);
-}
-
-.markdown-content tr {
-  border-bottom: 1px solid var(--Colors-Stroke-Default);
-}
-
-.markdown-content tbody tr:last-child {
-  border-bottom: none;
-}
-
-.markdown-content th,
-.markdown-content td {
-  padding: var(--UI-Spacing-spacing-mxs, 12px) var(--UI-Spacing-spacing-ms, 16px);
-  text-align: left;
-  vertical-align: top;
-  border-right: 1px solid var(--Colors-Stroke-Default);
-}
-
-.markdown-content th:last-child,
-.markdown-content td:last-child {
-  border-right: none;
-}
-
-.markdown-content th {
-  color: var(--Colors-Text-Body-Strong);
-  font-weight: 500;
-  -webkit-font-smoothing: antialiased;
-}
-
-.markdown-content td {
-  color: var(--Colors-Text-Body-Default);
-}
-
-.markdown-content table code {
-  white-space: nowrap;
-}
-
 /* Scroll indicator - shows when there's more content below */
 .scroll-indicator {
   position: fixed;

--- a/public/styles.css
+++ b/public/styles.css
@@ -156,6 +156,66 @@ blockquote + p,  blockquote + h1, blockquote + h2, blockquote + h3, blockquote +
   margin-top: 1.5em;
 }
 
+.markdown-content {
+  max-width: 100%;
+}
+
+.markdown-content table {
+  display: block;
+  width: fit-content;
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+  margin: 1em 0;
+  background: var(--Colors-Backgrounds-Main-Top);
+  border: 1px solid var(--Colors-Stroke-Default);
+  border-radius: var(--UI-Radius-radius-s, 8px);
+}
+
+.markdown-content thead {
+  background: var(--Colors-Backgrounds-Main-Medium);
+}
+
+.markdown-content tbody {
+  background: var(--Colors-Backgrounds-Main-Top);
+}
+
+.markdown-content tr {
+  border-bottom: 1px solid var(--Colors-Stroke-Default);
+}
+
+.markdown-content tbody tr:last-child {
+  border-bottom: none;
+}
+
+.markdown-content th,
+.markdown-content td {
+  padding: var(--UI-Spacing-spacing-mxs, 12px) var(--UI-Spacing-spacing-ms, 16px);
+  text-align: left;
+  vertical-align: top;
+  border-right: 1px solid var(--Colors-Stroke-Default);
+}
+
+.markdown-content th:last-child,
+.markdown-content td:last-child {
+  border-right: none;
+}
+
+.markdown-content th {
+  color: var(--Colors-Text-Body-Strong);
+  font-weight: 500;
+  -webkit-font-smoothing: antialiased;
+}
+
+.markdown-content td {
+  color: var(--Colors-Text-Body-Default);
+}
+
+.markdown-content table code {
+  white-space: nowrap;
+}
+
 /* Scroll indicator - shows when there's more content below */
 .scroll-indicator {
   position: fixed;

--- a/server.js
+++ b/server.js
@@ -53,6 +53,11 @@ const MIME_TYPES = {
   '.txt': 'text/plain; charset=utf-8'
 };
 
+const MARKDOWN_RENDERER = new marked.Renderer();
+MARKDOWN_RENDERER.table = function renderMarkdownTable(header, body) {
+  return `<div class="table-scroll"><table class="table">\n<thead>${header}</thead>\n<tbody>${body}</tbody>\n</table></div>`;
+};
+
 function isPathInside(child, parent) {
   const relative = path.relative(parent, child);
   return !!relative && !relative.startsWith('..') && !path.isAbsolute(relative);
@@ -141,6 +146,11 @@ function extractQuestionTypeFromMarkdown(markdownText) {
 function escapeMathDollars(markdown) {
   if (!markdown || typeof markdown !== 'string') return markdown;
   return markdown.replace(/\\\$/g, '<span class="no-math">$</span>');
+}
+
+function renderMarkdown(markdown) {
+  if (!markdown || typeof markdown !== 'string') return '';
+  return marked.parse(escapeMathDollars(markdown), { renderer: MARKDOWN_RENDERER });
 }
 
 /**
@@ -413,8 +423,8 @@ function buildActivityFromMarkdown(markdownText) {
       [choices[i], choices[j]] = [choices[j], choices[i]];
     }
     // Render markdown to HTML for prompt and content
-    const promptHtml = prompt ? marked.parse(escapeMathDollars(prompt)) : '';
-    const contentHtml = marked.parse(escapeMathDollars(contentWithBlankSpans));
+    const promptHtml = prompt ? renderMarkdown(prompt) : '';
+    const contentHtml = renderMarkdown(contentWithBlankSpans);
     // Parse QuestionStyle (e.g. "boxed", "bordered") from __QuestionStyle__ section
     const questionStyleTokens = sections.get('QuestionStyle') || [];
     const questionStyle = ((questionStyleTokens.map(t => t.raw || t.text).join('\n') || '').trim()).toLowerCase() || null;
@@ -422,7 +432,7 @@ function buildActivityFromMarkdown(markdownText) {
     const fibHeadingMd = fibHeadingTokens.map(t => t.raw || t.text).join('\n').trim();
     let fibHeading = null;
     if (fibHeadingMd) {
-      fibHeading = { markdown: fibHeadingMd, html: marked.parse(escapeMathDollars(fibHeadingMd)) };
+      fibHeading = { markdown: fibHeadingMd, html: renderMarkdown(fibHeadingMd) };
     }
     return attachSideContent(
       {
@@ -505,7 +515,7 @@ function buildActivityFromMarkdown(markdownText) {
         optionMap.set(label, text);
         
         // Parse markdown to HTML for rendering (supports images, bold, etc.)
-        const textHtml = marked.parse(escapeMathDollars(text));
+        const textHtml = renderMarkdown(text);
         
         options.push({
           label: label,
@@ -523,7 +533,7 @@ function buildActivityFromMarkdown(markdownText) {
       
       // Parse markdown to HTML for rendering (supports multiple paragraphs, blockquotes, etc.)
       if (currentQuestion.text) {
-        currentQuestion.textHtml = marked.parse(escapeMathDollars(currentQuestion.text));
+        currentQuestion.textHtml = renderMarkdown(currentQuestion.text);
       } else {
         currentQuestion.textHtml = '';
       }
@@ -740,7 +750,7 @@ function buildActivityFromMarkdown(markdownText) {
     if (headingBuffer.length > 0) {
       const headingText = headingBuffer.map(t => t.raw || t.text || '').join('\n').trim();
       if (headingText) {
-        heading = { markdown: headingText, html: marked.parse(escapeMathDollars(headingText)) };
+        heading = { markdown: headingText, html: renderMarkdown(headingText) };
       }
     }
 
@@ -790,7 +800,7 @@ function buildActivityFromMarkdown(markdownText) {
         const textBeforeBlank = itemLine.replace(/\[\[blank:[^\]]+\]\]/gi, '').trim();
         
         // Render text without blank to HTML
-        const textHtml = marked.parse(escapeMathDollars(textBeforeBlank));
+        const textHtml = renderMarkdown(textBeforeBlank);
         
         items.push({
           index: idx++,
@@ -828,13 +838,13 @@ function buildActivityFromMarkdown(markdownText) {
     }
     
     // Render markdown to HTML for prompt
-    const promptHtml = prompt ? marked.parse(escapeMathDollars(prompt)) : '';
+    const promptHtml = prompt ? renderMarkdown(prompt) : '';
 
     const matchingHeadingTokens = sections.get('Heading') || [];
     const matchingHeadingMd = matchingHeadingTokens.map(t => t.raw || t.text).join('\n').trim();
     let matchingHeading = null;
     if (matchingHeadingMd) {
-      matchingHeading = { markdown: matchingHeadingMd, html: marked.parse(escapeMathDollars(matchingHeadingMd)) };
+      matchingHeading = { markdown: matchingHeadingMd, html: renderMarkdown(matchingHeadingMd) };
     }
 
     return attachSideContent({
@@ -872,7 +882,7 @@ function buildActivityFromMarkdown(markdownText) {
       
       // Parse markdown to HTML for rendering (supports LaTeX, images, bold, etc.)
       if (currentQuestion.text) {
-        currentQuestion.textHtml = marked.parse(escapeMathDollars(currentQuestion.text));
+        currentQuestion.textHtml = renderMarkdown(currentQuestion.text);
       } else {
         currentQuestion.textHtml = '';
       }
@@ -1082,7 +1092,7 @@ function buildActivityFromMarkdown(markdownText) {
     if (headingBuffer.length > 0) {
       const headingText = headingBuffer.map(t => t.raw || t.text || '').join('\n').trim();
       if (headingText) {
-        heading = { markdown: headingText, html: marked.parse(escapeMathDollars(headingText)) };
+        heading = { markdown: headingText, html: renderMarkdown(headingText) };
       }
     }
     
@@ -1165,10 +1175,10 @@ function buildActivityFromMarkdown(markdownText) {
     const headingMd = headingTokens.map(t => t.raw || t.text).join('\n').trim();
     let matrixHeading = null;
     if (headingMd) {
-      matrixHeading = { markdown: headingMd, html: marked.parse(escapeMathDollars(headingMd)) };
+      matrixHeading = { markdown: headingMd, html: renderMarkdown(headingMd) };
     }
 
-    const questionHtml = question ? marked.parse(escapeMathDollars(question)) : '';
+    const questionHtml = question ? renderMarkdown(question) : '';
 
     return attachSideContent(
       {
@@ -1488,7 +1498,7 @@ const server = http.createServer((req, res) => {
       try {
         const data = JSON.parse(body);
         const markdown = data.markdown || '';
-        const html = marked.parse(markdown);
+        const html = renderMarkdown(markdown);
         
         // Return HTML wrapped in a proper document with styles
         const fullHtml = `<!DOCTYPE html>
@@ -1500,6 +1510,7 @@ const server = http.createServer((req, res) => {
   <link rel="stylesheet" href="/design-system/colors/colors.css" />
   <link rel="stylesheet" href="/design-system/typography/typography.css" />
   <link rel="stylesheet" href="/design-system/spacing/spacing.css" />
+  <link rel="stylesheet" href="/design-system/components/table/table.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" crossorigin="anonymous">
   <style>
     body {
@@ -1511,52 +1522,6 @@ const server = http.createServer((req, res) => {
     }
     .markdown-content {
       max-width: 100%;
-    }
-    .markdown-content table {
-      display: block;
-      width: fit-content;
-      min-width: 0;
-      max-width: 100%;
-      overflow-x: auto;
-      border-collapse: collapse;
-      margin: 1em 0;
-      background: var(--Colors-Backgrounds-Main-Top);
-      border: 1px solid var(--Colors-Stroke-Default);
-      border-radius: 8px;
-    }
-    .markdown-content thead {
-      background: var(--Colors-Backgrounds-Main-Medium);
-    }
-    .markdown-content tbody {
-      background: var(--Colors-Backgrounds-Main-Top);
-    }
-    .markdown-content tr {
-      border-bottom: 1px solid var(--Colors-Stroke-Default);
-    }
-    .markdown-content tbody tr:last-child {
-      border-bottom: none;
-    }
-    .markdown-content th,
-    .markdown-content td {
-      padding: 12px 16px;
-      text-align: left;
-      vertical-align: top;
-      border-right: 1px solid var(--Colors-Stroke-Default);
-    }
-    .markdown-content th:last-child,
-    .markdown-content td:last-child {
-      border-right: none;
-    }
-    .markdown-content th {
-      color: var(--Colors-Text-Body-Strong);
-      font-weight: 500;
-      -webkit-font-smoothing: antialiased;
-    }
-    .markdown-content td {
-      color: var(--Colors-Text-Body-Default);
-    }
-    .markdown-content table code {
-      white-space: nowrap;
     }
     @media (prefers-color-scheme: dark) {
       body {

--- a/server.js
+++ b/server.js
@@ -1419,6 +1419,55 @@ const server = http.createServer((req, res) => {
       color: var(--Colors-Text-Body-Default);
       font-family: var(--body-family);
     }
+    .markdown-content {
+      max-width: 100%;
+    }
+    .markdown-content table {
+      display: block;
+      width: fit-content;
+      min-width: 0;
+      max-width: 100%;
+      overflow-x: auto;
+      border-collapse: collapse;
+      margin: 1em 0;
+      background: var(--Colors-Backgrounds-Main-Top);
+      border: 1px solid var(--Colors-Stroke-Default);
+      border-radius: 8px;
+    }
+    .markdown-content thead {
+      background: var(--Colors-Backgrounds-Main-Medium);
+    }
+    .markdown-content tbody {
+      background: var(--Colors-Backgrounds-Main-Top);
+    }
+    .markdown-content tr {
+      border-bottom: 1px solid var(--Colors-Stroke-Default);
+    }
+    .markdown-content tbody tr:last-child {
+      border-bottom: none;
+    }
+    .markdown-content th,
+    .markdown-content td {
+      padding: 12px 16px;
+      text-align: left;
+      vertical-align: top;
+      border-right: 1px solid var(--Colors-Stroke-Default);
+    }
+    .markdown-content th:last-child,
+    .markdown-content td:last-child {
+      border-right: none;
+    }
+    .markdown-content th {
+      color: var(--Colors-Text-Body-Strong);
+      font-weight: 500;
+      -webkit-font-smoothing: antialiased;
+    }
+    .markdown-content td {
+      color: var(--Colors-Text-Body-Default);
+    }
+    .markdown-content table code {
+      white-space: nowrap;
+    }
     @media (prefers-color-scheme: dark) {
       body {
         background-color: var(--Colors-Backgrounds-Main-Top);
@@ -1428,7 +1477,7 @@ const server = http.createServer((req, res) => {
   </style>
 </head>
 <body>
-  <div class="body-medium">${html}</div>
+  <div class="body-medium markdown-content">${html}</div>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js" crossorigin="anonymous"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js" crossorigin="anonymous"></script>
   <script>


### PR DESCRIPTION
## Summary

Closes #6

This PR adds support for Markdown tables across the main activity rendering paths.

The fix is intentionally scoped to Markdown-rendered content and avoids changing the Matrix activity's own table UI.

## What changed

- Added shared table styling for Markdown-rendered content in the main app.
- Applied the same table styling to iframe-rendered Markdown content used by `__Content__`.
- Fixed `Fill in the Blanks` so rendered tables are preserved instead of being discarded during paragraph-only restructuring.
- Scoped Markdown table styling so it does not affect the Matrix activity table component.

## Why

Markdown tables were not supported consistently across the app.

In practice:
- `Text Input` and `Multiple Choice` could parse table HTML, but lacked shared styling.
- `Fill in the Blanks` could lose tables entirely because the client only kept paragraph blocks containing blanks.
- Side-content Markdown rendered in the iframe did not inherit the same styling as the main app.

## Testing

Manual test cases used for validation:
- FIB with a reference table followed by blank sentences
- FIB with blanks directly inside table cells
- Text Input with a reference table in the prompt
- Multiple Choice with a table in the question stem
- Side-content Markdown with a table in the left panel
- Matrix with a table in the prompt text

Files prepared separately for reviewers:
- [fib-reference-table.md](https://github.com/user-attachments/files/26679641/fib-reference-table.md)
- [fib-blanks-inside-table.md](https://github.com/user-attachments/files/26679640/fib-blanks-inside-table.md)
- [text-input-table.md](https://github.com/user-attachments/files/26679646/text-input-table.md)
- [mcq-table.md](https://github.com/user-attachments/files/26679643/mcq-table.md)
- [side-content-table.md](https://github.com/user-attachments/files/26679645/side-content-table.md)
- [matrix-prompt-table.md](https://github.com/user-attachments/files/26679642/matrix-prompt-table.md)


## Notes

- `npm test` is still the default placeholder script in this repo, so there is no real automated test suite yet.
- Syntax checks were run on the edited JavaScript files.
- The change is designed to be backward compatible by scoping styles to Markdown content only.
