### PR TITLE
Remove unnecessary Next button from multi-select MCQ questions

### DIFF
--- a/public/modules/mcq.js
+++ b/public/modules/mcq.js
@@ -242,8 +242,8 @@ export function initMcq({
       questionEl.appendChild(explainContainer);
     }
     
-    // Add "Next" button for multi-select questions or questions with explainAnswer (not on last question)
-    if ((question.isMultiSelect || question.explainAnswer) && qIdx < mcq.questions.length - 1) {
+    // Add "Next" button for questions with explainAnswer (not on last question)
+    if (question.explainAnswer && qIdx < mcq.questions.length - 1) {
       const nextButtonContainer = document.createElement('div');
       nextButtonContainer.className = 'mcq-next-button-container';
       

--- a/public/modules/mcq.js
+++ b/public/modules/mcq.js
@@ -295,14 +295,13 @@ export function initMcq({
         selectedAnswers[questionId] = selectedAnswers[questionId].filter(l => l !== optionLabel);
       }
       
-      // Enable/disable next button for multi-select questions based on selection
-      const questionEl = elQuestions.querySelector(`[data-question-id="${questionId}"]`);
-      if (questionEl) {
-        const nextButton = questionEl.querySelector('.mcq-next-button');
-        if (nextButton) {
-          const hasSelection = selectedAnswers[questionId].length > 0;
-          // Disable if no answer selected
-          nextButton.disabled = !hasSelection;
+      if (question.explainAnswer) {
+        const questionEl = elQuestions.querySelector(`[data-question-id="${questionId}"]`);
+        if (questionEl) {
+          const nextButton = questionEl.querySelector('.mcq-next-button');
+          if (nextButton) {
+            nextButton.disabled = selectedAnswers[questionId].length === 0;
+          }
         }
       }
     } else {


### PR DESCRIPTION
Multi-select questions were showing a Next button to advance to the next question, but this isn't needed — users can scroll naturally. The Next button is now only rendered for questions that use explainAnswer, where explicit progression makes sense.