### PR TITLE
Implemented changes required to use /sim/ in split screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,71 @@ Then open **http://localhost:3000/**. You get a split layout: a searchable list 
 
 This mode is intended for local development and QA only. The same static assets and activity APIs apply as in normal mode; only the root route and the extra example APIs are added (see **API Endpoints** below).
 
+### Side content & split-screen layout
+
+Any activity can render **side content** in a split layout by adding a `__Content__` section. The activity UI appears on the right and the side content on the left, with a draggable divider between them. `__Content__` accepts three forms:
+
+| Form | First line of `__Content__` | Use case |
+|------|------------------------------|----------|
+| **External URL** | `https://example.com/docs` | Embed external documentation, datasets, web tools, etc. |
+| **Inline markdown** | Any markdown block (no URL on the first line) | Reference tables, formulas, hints, glossaries — rendered inline. |
+| **Site-relative URL** | `/sim/` (or any path starting with `/`) | Embed a simulation hosted by this server (split-screen mode — see below). |
+
+Optional modifiers on the same line / block:
+
+- `[contentWidth: 50%]` or `[contentWidth: 320px]` — initial width of the left pane (defaults to 40%).
+- `[openInNewTab]` — adds a toolbar button to open the URL in a new tab (URL forms only).
+
+Examples are in `data/examples/`:
+
+- `mcq-with-url-content.md`, `text-input-with-url-content.md` — external URL
+- `text-input-with-markdown-content.md`, `side-content-markdown-table.md` — inline markdown
+
+#### Split-screen mode with an external simulation
+
+A site-relative URL form (`/sim/...`) lets you embed a simulation-as-content that runs as a **separate process** alongside the activity server. The activity server reverse-proxies the simulation under **`/sim/`** so the iframe can load it with a relative URL
+
+Enable the proxy by setting **`SIM_ORIGIN`** to the simulation's HTTP origin and starting the activity server normally:
+
+```bash
+# 1. Start your simulation on a different port (example: 3001)
+PORT=3001 ./run-your-sim.sh &
+
+# 2. Start the activity server with the proxy enabled
+SIM_ORIGIN=http://127.0.0.1:3001 npm start
+```
+
+In your activity's `__Content__` section, reference the simulation with a site-relative path under the mount point:
+
+```markdown
+__Type__
+
+Multiple Choice
+
+__Content__
+
+/sim/ [contentWidth: 50%]
+
+__Practice Question__
+
+...
+```
+
+The iframe loads from `https://<preview-host>/sim/`, which the activity server forwards to `SIM_ORIGIN`. Static assets and APIs the simulation requests at root paths (`/assets/*`, `/configs/*`, `/api/logs`) are forwarded too — these defaults match common simulation layouts but can be overridden.
+
+##### Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `SIM_ORIGIN` | _(unset — proxy disabled)_ | HTTP(S) origin of the simulation backend, e.g. `http://127.0.0.1:3001`. When unset, the activity server behaves exactly as before (no proxy). |
+| `SIM_ROOT_PROXY_PATHS` | `/assets/,/configs/,/api/logs` | Comma-separated list of root-absolute paths the simulation expects to serve directly. Override when integrating a simulation that uses a different layout. Avoid listing paths that collide with the activity server's own routes (`/api/activity`, `/api/results`, `/design-system/*`, etc.). |
+
+The proxy supports HTTP and HTTPS upstreams (transport is chosen automatically from `SIM_ORIGIN`'s scheme) and forwards query strings, request methods, and bodies.
+
+##### Standalone use is unaffected
+
+`SIM_ORIGIN` is opt-in. If it is not set, the activity server serves only its own routes and no requests are forwarded — the runtime behaves identically to previous versions.
+
 ## Project Structure
 
 ```
@@ -88,6 +153,11 @@ When the server is started with **`--examples`**:
 
 - `GET /api/examples/list` - Returns `{ "examples": [ "file.md", ... ] }` (sorted basenames of `data/examples/*.md`)
 - `POST /api/examples/select` - Body: `{ "filename": "mcq.md" }`. Copies that file from `data/examples/` to `data/question.md` (basename must match a safe pattern). Response: `{ "success": true, "filename": "..." }` or an error object.
+
+When **`SIM_ORIGIN`** is set (split-screen mode):
+
+- `ANY /sim/*` - Reverse-proxied to `SIM_ORIGIN` with the `/sim` prefix stripped (e.g. `/sim/foo?x=1` → `SIM_ORIGIN/foo?x=1`).
+- `ANY <path>` where `<path>` matches `SIM_ROOT_PROXY_PATHS` - Reverse-proxied to `SIM_ORIGIN` unchanged. Used for simulation static assets and APIs that live at root paths.
 
 ## Development
 

--- a/data/examples/fib-split-screen-sim.md
+++ b/data/examples/fib-split-screen-sim.md
@@ -1,0 +1,19 @@
+__Type__
+
+Fill In The Blanks
+
+__Content__
+
+/sim/ [contentWidth: 50%]
+
+__Markdown With Blanks__
+
+Observe the simulation on the left, then complete the sentences.
+
+> The simulation is served from a separate process and reverse-proxied under [[blank:sim]] by the activity server. The live clock in the panel updates every [[blank:second]], confirming the iframe is connected. The status badge at the top shows the word [[blank:Online]].
+
+__Suggested Answers__
+
+- sim
+- second
+- Online

--- a/data/examples/matching-split-screen-sim.md
+++ b/data/examples/matching-split-screen-sim.md
@@ -1,0 +1,24 @@
+__Type__
+
+Matching
+
+__Content__
+
+/sim/ [contentWidth: 50%]
+
+__Markdown With Blanks__
+
+> **Panel element 1**: Shown at the very top of the simulation — a small colored pill with a dot icon [[blank:Status badge]]
+
+> **Panel element 2**: Large gradient text that reads "Hello World Simulation" [[blank:Heading]]
+
+> **Panel element 3**: A dark card listing runtime details such as port and proxy path [[blank:Info card]]
+
+> **Panel element 4**: Ticking display showing the current local time [[blank:Live clock]]
+
+__Suggested Answers__
+
+- Status badge
+- Heading
+- Info card
+- Live clock

--- a/data/examples/matrix-split-screen-sim.md
+++ b/data/examples/matrix-split-screen-sim.md
@@ -1,0 +1,30 @@
+__Type__
+
+Matrix
+
+__Content__
+
+/sim/ [contentWidth: 50%]
+
+__Practice Question__
+
+Based on the simulation panel on the left, classify each statement as True or False.
+
+__Matrix Columns__
+
+- True
+- False
+
+__Matrix Rows__
+
+- The simulation is proxied under /sim/
+- The simulation port shown is 3000
+- The clock in the panel updates in real time
+- The simulation requires an internet connection
+
+__Suggested Answers__
+
+- The simulation is proxied under /sim/: True
+- The simulation port shown is 3000: False
+- The clock in the panel updates in real time: True
+- The simulation requires an internet connection: False

--- a/data/examples/mcq-split-screen-sim.md
+++ b/data/examples/mcq-split-screen-sim.md
@@ -1,0 +1,23 @@
+__Type__
+
+Multiple Choice
+
+__Content__
+
+/sim/ [contentWidth: 50%]
+
+__Practice Question__
+
+Looking at the simulation on the left, what best describes its current status?
+
+A. It is offline and unreachable
+B. It is running and proxied through /sim/
+C. It is loading but not yet ready
+D. It is an external third-party website
+
+__Suggested Answers__
+
+- A
+- B - Correct
+- C
+- D

--- a/data/examples/text-input-split-screen-sim.md
+++ b/data/examples/text-input-split-screen-sim.md
@@ -1,0 +1,31 @@
+__Type__
+
+Text Input
+
+__Content__
+
+/sim/ [contentWidth: 50%]
+
+__Practice Question__
+
+Look at the simulation panel on the left. What path does it say it is proxied under? (Enter exactly as shown, including the leading slash)
+
+__Correct Answers__
+
+- /sim/ [kind: string] [options: caseSensitive=false,fuzzy=false]
+
+__Practice Question__
+
+What color is the pulsing status dot in the simulation panel? (one word)
+
+__Correct Answers__
+
+- green [kind: string] [options: caseSensitive=false,fuzzy=false]
+
+__Practice Question__
+
+What port number is the simulation running on? (digits only)
+
+__Correct Answers__
+
+- 8080 [kind: numeric] [options: threshold=0,precision=0]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "node --test \"test/**/*.test.js\"",
     "start": "node server.js",
-    "examples": "node server.js --examples",
+    "examples": "SIM_ORIGIN=http://127.0.0.1:8080 concurrently --kill-others \"node sim-server.js\" \"node server.js --examples\"",
     "dev:reload": "concurrently \"node server.js\" \"browser-sync start --proxy http://localhost:3000 --files '**/*.css, **/*.html, **/*.js, data/question.md' --ignore node_modules\""
   },
   "keywords": [],

--- a/public/editor.js
+++ b/public/editor.js
@@ -16,6 +16,17 @@ function parseContentTextToStructure(contentText) {
     if (contentWidth) out.contentWidth = contentWidth;
     return out;
   }
+
+  const pathLines = contentWithoutWidth.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+  const pathFirst = pathLines[0] || '';
+  if (pathFirst.startsWith('/')) {
+    const openInNewTab = /\[openInNewTab\]/i.test(contentWithoutWidth);
+    const url = pathFirst.replace(/\s+\[openInNewTab\]\s*$/i, '').trim();
+    const out = { type: 'url', value: url, openInNewTab: !!openInNewTab };
+    if (contentWidth) out.contentWidth = contentWidth;
+    return out;
+  }
+
   const out = { type: 'markdown', value: contentWithoutWidth };
   if (contentWidth) out.contentWidth = contentWidth;
   return out;
@@ -179,7 +190,7 @@ function parseAnswerLine(answerLine) {
   // Check if the line starts with [kind: (empty answer case)
   const trimmedLine = answerLine.trim();
   const startsWithKind = trimmedLine.startsWith('[kind:');
-  
+
   let validationMatch;
   if (startsWithKind) {
     // Handle case where answer is empty: "[kind: string] [options: ...]"
@@ -197,7 +208,7 @@ function parseAnswerLine(answerLine) {
     // Normal case: "answer [kind: string] [options: ...]"
     validationMatch = trimmedLine.match(/^(.+?)(?:\s+\[kind:\s*([^\]]+)\])?(?:\s+\[options:\s*([^\]]+)\])?$/);
   }
-  
+
   if (!validationMatch) {
     return {
       correctAnswer: trimmedLine,
@@ -206,9 +217,9 @@ function parseAnswerLine(answerLine) {
   }
 
   const correctAnswer = startsWithKind ? '' : validationMatch[1].trim();
-  const kind = (startsWithKind ? validationMatch[1] : validationMatch[2]) ? 
+  const kind = (startsWithKind ? validationMatch[1] : validationMatch[2]) ?
     (startsWithKind ? validationMatch[1].trim() : validationMatch[2].trim()) : 'string';
-  const optionsText = (startsWithKind ? validationMatch[2] : validationMatch[3]) ? 
+  const optionsText = (startsWithKind ? validationMatch[2] : validationMatch[3]) ?
     (startsWithKind ? validationMatch[2] : validationMatch[3].trim()) : '';
 
   const options = parseOptions(optionsText);
@@ -383,7 +394,7 @@ function renderQuestion(question, index) {
 
   const header = document.createElement('div');
   header.className = 'question-item-header';
-  
+
   const title = document.createElement('div');
   title.className = 'question-item-title';
   title.textContent = `Question ${index + 1}`;
@@ -391,7 +402,7 @@ function renderQuestion(question, index) {
   const kindDropdownContainer = document.createElement('div');
   kindDropdownContainer.style.marginLeft = 'var(--UI-Spacing-spacing-l)';
   kindDropdownContainer.style.width = '240px';
-  
+
   const kindDropdown = new Dropdown(kindDropdownContainer, {
     items: [
       { value: 'string', label: 'String' },
@@ -408,7 +419,7 @@ function renderQuestion(question, index) {
       renderValidationOptions(container, question, index);
     }
   });
-  
+
   // Store dropdown instance for potential updates
   questionDropdowns.set(index, kindDropdown);
 
@@ -1707,7 +1718,7 @@ function parseMcqMarkdownToStructure(markdown) {
         currentQuestion.options = options;
       }
     }
-    
+
     // Process question options if we're in that section
     if (questionOptionsBuffer.length > 0) {
       const optionsText = questionOptionsBuffer.join('\n').trim().toLowerCase();
@@ -1715,7 +1726,7 @@ function parseMcqMarkdownToStructure(markdown) {
         currentQuestion.shuffleOptions = false;
       }
     }
-    
+
     // Process answers if we have answer buffer (we were in answers section)
     if (answerBuffer.length > 0 && currentQuestion.options && currentQuestion.options.length > 0) {
       const answerItems = answerBuffer.map(line => line.trim()).filter(line => line.startsWith('-'));
@@ -1735,7 +1746,7 @@ function parseMcqMarkdownToStructure(markdown) {
       });
       currentQuestion.isMultiSelect = correctAnswers.size > 1;
     }
-    
+
     // Process explain answer if we're in explain section
     if (explainAnswerBuffer.length > 0) {
       const { enabled, label } = parseExplainYourAnswerBody(explainAnswerBuffer.join('\n'));
@@ -1774,13 +1785,13 @@ function mcqStructureToMarkdown(structure) {
       markdown += `__Question Name__\n\n${String(q.name).trim()}\n\n`;
     }
     markdown += `__Practice Question__\n\n${q.text}\n\n`;
-    
+
     // Add options
     q.options.forEach(opt => {
       markdown += `${opt.label}. ${opt.text}\n`;
     });
     markdown += '\n';
-    
+
     // Add question options if shuffle is disabled or multi-select mode is "any"
     const hasOptions = q.shuffleOptions === false || (q.multiSelectMode === 'any');
     if (hasOptions) {
@@ -1793,7 +1804,7 @@ function mcqStructureToMarkdown(structure) {
       }
       markdown += '\n';
     }
-    
+
     // Add suggested answers
     markdown += `__Suggested Answers__\n\n`;
     q.options.forEach(opt => {
@@ -1801,7 +1812,7 @@ function mcqStructureToMarkdown(structure) {
       markdown += `- ${opt.label}${correctMarker}\n`;
     });
     markdown += '\n';
-    
+
     // Add explain your answer if enabled
     if (q.explainAnswer) {
       markdown += `__Explain Your Answer__\n\ntrue\n`;
@@ -1842,7 +1853,7 @@ function renderMcqQuestion(question, index) {
 
   const header = document.createElement('div');
   header.className = 'question-item-header';
-  
+
   const title = document.createElement('div');
   title.className = 'question-item-title';
   title.textContent = `Question ${index + 1}`;
@@ -1955,7 +1966,7 @@ function renderMcqQuestion(question, index) {
     const correctCheckbox = document.createElement('label');
     correctCheckbox.className = 'input-checkbox';
     correctCheckbox.style.flexShrink = '0';
-    
+
     const checkboxInput = document.createElement('input');
     checkboxInput.type = 'checkbox';
     checkboxInput.checked = option.correct || false;
@@ -2062,7 +2073,7 @@ function renderMcqQuestion(question, index) {
       const correctCheckbox = document.createElement('label');
       correctCheckbox.className = 'input-checkbox';
       correctCheckbox.style.flexShrink = '0';
-      
+
       const checkboxInput = document.createElement('input');
       checkboxInput.type = 'checkbox';
       checkboxInput.checked = opt.correct || false;
@@ -2223,7 +2234,7 @@ function renderMcqQuestion(question, index) {
   modeLabel.className = 'input-checkbox';
   modeLabel.style.marginTop = 'var(--UI-Spacing-spacing-ms)';
   modeLabel.style.display = 'none'; // Hidden by default
-  
+
   const modeInput = document.createElement('input');
   modeInput.type = 'checkbox';
   modeInput.checked = question.multiSelectMode === 'any';
@@ -2231,22 +2242,22 @@ function renderMcqQuestion(question, index) {
     question.multiSelectMode = modeInput.checked ? 'any' : 'all';
     updateStructure();
   };
-  
+
   const modeBox = document.createElement('span');
   modeBox.className = 'input-checkbox-box';
   const modeCheckmark = document.createElement('span');
   modeCheckmark.className = 'input-checkbox-checkmark';
   modeBox.appendChild(modeCheckmark);
-  
+
   const modeText = document.createElement('span');
   modeText.className = 'input-checkbox-label';
   modeText.textContent = 'Any Correct Answer is Sufficient';
-  
+
   modeLabel.appendChild(modeInput);
   modeLabel.appendChild(modeBox);
   modeLabel.appendChild(modeText);
   questionOptionsDiv.appendChild(modeLabel);
-  
+
   // Function to update multi-select mode checkbox visibility
   function updateMultiSelectModeVisibility() {
     const correctCount = question.options.filter(opt => opt.correct).length;
@@ -2261,10 +2272,10 @@ function renderMcqQuestion(question, index) {
       modeInput.checked = false;
     }
   }
-  
+
   // Initial check
   updateMultiSelectModeVisibility();
-  
+
   // Store the update function on the container so we can call it when options change
   container.updateMultiSelectModeVisibility = updateMultiSelectModeVisibility;
 
@@ -2617,7 +2628,7 @@ function wireContentEditorPanel() {
 
     function createContentInput(type, value, openInNewTab = false, contentWidth = '') {
       contentInputContainer.innerHTML = '';
-      
+
       if (type === 'url') {
         contentInput = document.createElement('input');
         contentInput.type = 'text';
@@ -2626,7 +2637,7 @@ function wireContentEditorPanel() {
         contentInput.placeholder = 'https://example.com';
         contentInput.value = value || '';
         contentInputContainer.appendChild(contentInput);
-        
+
         contentInput.oninput = debounce(() => {
           if (currentStructure.content) {
             currentStructure.content.value = contentInput.value;
@@ -2696,7 +2707,7 @@ function wireContentEditorPanel() {
         contentInput.placeholder = 'Enter markdown content...';
         contentInput.value = value || '';
         contentInputContainer.appendChild(contentInput);
-        
+
         contentInput.oninput = debounce(() => {
           if (currentStructure.content) {
             currentStructure.content.value = contentInput.value;
@@ -2730,12 +2741,12 @@ function wireContentEditorPanel() {
         contentInputContainer.appendChild(contentWidthGroup);
       }
     }
-    
+
     function createOpenUrlButton() {
       if (openUrlButton) {
         openUrlButton.remove();
       }
-      
+
       if (contentTypeDropdown && contentTypeDropdown.getValue() === 'url') {
         openUrlButton = document.createElement('button');
         openUrlButton.id = 'content-open-url-btn';
@@ -2749,47 +2760,47 @@ function wireContentEditorPanel() {
         openUrlButton.style.verticalAlign = 'middle';
         openUrlButton.style.lineHeight = '1';
         openUrlButton.setAttribute('aria-label', 'Open URL in new tab');
-        
+
         const iconSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
         iconSvg.setAttribute('width', '16');
         iconSvg.setAttribute('height', '16');
         iconSvg.setAttribute('viewBox', '0 0 16 16');
         iconSvg.setAttribute('fill', 'none');
         iconSvg.style.display = 'block';
-        
+
         const path1 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
         path1.setAttribute('d', 'M10 2H4C3.44772 2 3 2.44772 3 3V12C3 12.5523 3.44772 13 4 13H13C13.5523 13 14 12.5523 14 12V6');
         path1.setAttribute('stroke', 'currentColor');
         path1.setAttribute('stroke-width', '1.5');
         path1.setAttribute('stroke-linecap', 'round');
         path1.setAttribute('stroke-linejoin', 'round');
-        
+
         const path2 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
         path2.setAttribute('d', 'M11 1H14V4');
         path2.setAttribute('stroke', 'currentColor');
         path2.setAttribute('stroke-width', '1.5');
         path2.setAttribute('stroke-linecap', 'round');
         path2.setAttribute('stroke-linejoin', 'round');
-        
+
         const path3 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
         path3.setAttribute('d', 'M6 10L14 2');
         path3.setAttribute('stroke', 'currentColor');
         path3.setAttribute('stroke-width', '1.5');
         path3.setAttribute('stroke-linecap', 'round');
         path3.setAttribute('stroke-linejoin', 'round');
-        
+
         iconSvg.appendChild(path1);
         iconSvg.appendChild(path2);
         iconSvg.appendChild(path3);
         openUrlButton.appendChild(iconSvg);
-        
+
         const updateButtonState = () => {
           if (contentInput && openUrlButton) {
             const urlValue = contentInput.value.trim();
             openUrlButton.disabled = !urlValue || !/^https?:\/\//i.test(urlValue);
           }
         };
-        
+
         openUrlButton.onclick = (e) => {
           e.preventDefault();
           if (contentInput) {
@@ -2799,10 +2810,10 @@ function wireContentEditorPanel() {
             }
           }
         };
-        
+
         contentLabel.parentNode.insertBefore(openUrlButton, contentLabel.nextSibling);
         updateButtonState();
-        
+
         if (contentInput) {
           const originalOnInput = contentInput.oninput;
           contentInput.oninput = debounce(() => {
@@ -2832,16 +2843,16 @@ function wireContentEditorPanel() {
         } else {
           contentInputGroup.style.display = 'block';
           contentLabel.textContent = value === 'url' ? 'URL' : 'Markdown Content';
-          
+
           const currentValue = currentStructure.content ? currentStructure.content.value : '';
           if (!currentStructure.content) {
             currentStructure.content = { type: value, value: '' };
           } else {
             currentStructure.content.type = value;
           }
-          
+
           createContentInput(value, currentValue, currentStructure.content?.openInNewTab, currentStructure.content?.contentWidth);
-          
+
           if (value === 'url') {
             createOpenUrlButton();
           } else {

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 const http = require('http');
+const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const { Lexer, marked } = require('marked');
@@ -1181,17 +1182,19 @@ function shouldProxyToSim(pathname) {
   return false;
 }
 
-function proxyToSim(req, res, pathname) {
+function proxyToSim(req, res, pathname, search) {
   const subpath = simUpstreamPath(pathname);
   const target = new URL(subpath, SIM_ORIGIN);
+  const isHttps = target.protocol === 'https:';
+  const transport = isHttps ? https : http;
   const options = {
     hostname: target.hostname,
-    port: target.port || (target.protocol === 'https:' ? 443 : 80),
-    path: target.pathname + target.search,
+    port: target.port || (isHttps ? 443 : 80),
+    path: target.pathname + (search || ''),
     method: req.method,
     headers: { ...req.headers, host: target.host }
   };
-  const proxyReq = http.request(options, (proxyRes) => {
+  const proxyReq = transport.request(options, (proxyRes) => {
     res.writeHead(proxyRes.statusCode, proxyRes.headers);
     proxyRes.pipe(res);
   });
@@ -1214,7 +1217,7 @@ const server = http.createServer((req, res) => {
   let pathname = decodeURIComponent(urlObj.pathname || '/');
 
   if (shouldProxyToSim(pathname)) {
-    proxyToSim(req, res, pathname);
+    proxyToSim(req, res, pathname, urlObj.search);
     return;
   }
 

--- a/server.js
+++ b/server.js
@@ -1160,7 +1160,11 @@ function buildActivityFromMarkdown(markdownText) {
 function simUpstreamPath(pathname) {
   if (pathname === SIM_MOUNT_PATH) return '/';
   const prefix = `${SIM_MOUNT_PATH}/`;
-  if (pathname.startsWith(prefix)) return pathname.slice(SIM_MOUNT_PATH.length) || '/';
+  if (pathname.startsWith(prefix)) {
+    const subpath = pathname.slice(SIM_MOUNT_PATH.length) || '/';
+    // Collapse leading slashes so subpath cannot resolve as a scheme-relative URL via new URL().
+    return `/${subpath.replace(/^\/+/, '')}`;
+  }
   return pathname;
 }
 

--- a/server.js
+++ b/server.js
@@ -1170,8 +1170,9 @@ function simUpstreamPath(pathname) {
 }
 
 function shouldProxyToSim(pathname) {
-  if (!SIM_ORIGIN) return false;
+  // Always intercept /sim/* so it never falls through to the activity page.
   if (pathname === SIM_MOUNT_PATH || pathname.startsWith(`${SIM_MOUNT_PATH}/`)) return true;
+  if (!SIM_ORIGIN) return false;
   for (const entry of SIM_ROOT_PROXY_PATHS) {
     if (entry.endsWith('/')) {
       if (pathname.startsWith(entry)) return true;
@@ -1182,7 +1183,51 @@ function shouldProxyToSim(pathname) {
   return false;
 }
 
+function simErrorHtml(message) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Simulation not found</title>
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #f8fafc;
+      color: #64748b;
+    }
+    .icon { font-size: 2.5rem; }
+    h1 { margin: 0; font-size: 1.1rem; font-weight: 600; color: #0f172a; }
+    p { margin: 0; font-size: 0.875rem; }
+    code {
+      font-size: 0.8rem;
+      background: #e2e8f0;
+      padding: 0.15rem 0.4rem;
+      border-radius: 4px;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+  <div class="icon">⚠️</div>
+  <h1>Simulation not reachable</h1>
+  <p>${message}</p>
+</body>
+</html>`;
+}
+
 function proxyToSim(req, res, pathname, search) {
+  if (!SIM_ORIGIN) {
+    res.writeHead(502, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(simErrorHtml('No simulation configured — <code>SIM_ORIGIN</code> is not set.'));
+    return;
+  }
   const subpath = simUpstreamPath(pathname);
   const target = new URL(subpath, SIM_ORIGIN);
   const isHttps = target.protocol === 'https:';
@@ -1199,8 +1244,8 @@ function proxyToSim(req, res, pathname, search) {
     proxyRes.pipe(res);
   });
   proxyReq.on('error', () => {
-    res.writeHead(502, { 'Content-Type': 'text/plain; charset=utf-8' });
-    res.end('Simulation not running on ' + SIM_ORIGIN);
+    res.writeHead(502, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(simErrorHtml(`Nothing is running at <code>${SIM_ORIGIN}</code>`));
   });
   if (req.method === 'GET' || req.method === 'HEAD') {
     proxyReq.end();

--- a/server.js
+++ b/server.js
@@ -21,6 +21,15 @@ const DATA_DIR = path.join(__dirname, 'data');
 const EXAMPLES_DIR = path.join(DATA_DIR, 'examples');
 const QUESTION_MD_PATH = path.join(DATA_DIR, 'question.md');
 
+/** When set, requests under /sim/ (and configured root paths) reverse-proxy to the simulation backend. */
+const SIM_ORIGIN = process.env.SIM_ORIGIN || null;
+const SIM_MOUNT_PATH = '/sim';
+/** Root-absolute paths some simulations request when embedded (e.g. bundled /assets/*). Override via SIM_ROOT_PROXY_PATHS. */
+const SIM_ROOT_PROXY_PATHS = (process.env.SIM_ROOT_PROXY_PATHS || '/assets/,/configs/,/api/logs')
+  .split(',')
+  .map((entry) => entry.trim())
+  .filter(Boolean);
+
 // Parse command line arguments for --edit, --copy-markdown, and --examples
 let EDIT_MODE = false;
 let EXAMPLES_MODE = false;
@@ -166,6 +175,7 @@ function renderMarkdown(markdown) {
 
 /**
  * Parse __Content__ section tokens into { url } or { markdown } plus optional contentWidth, openInNewTab.
+ * URLs may be absolute (https://...) or site-relative paths (/sim/...) for split-screen simulations.
  */
 function parseSideContentFromSectionTokens(sectionTokens) {
   if (!sectionTokens || sectionTokens.length === 0) return null;
@@ -186,6 +196,17 @@ function parseSideContentFromSectionTokens(sectionTokens) {
     if (contentWidth) out.contentWidth = contentWidth;
     return out;
   }
+
+  const pathLines = contentWithoutWidth.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+  const pathFirst = pathLines[0] || '';
+  if (pathFirst.startsWith('/')) {
+    const openInNewTab = /\[openInNewTab\]/i.test(contentWithoutWidth);
+    const url = pathFirst.replace(/\s+\[openInNewTab\]\s*$/i, '').trim();
+    const out = { url, openInNewTab: !!openInNewTab };
+    if (contentWidth) out.contentWidth = contentWidth;
+    return out;
+  }
+
   const out = { markdown: contentWithoutWidth };
   if (contentWidth) out.contentWidth = contentWidth;
   return out;
@@ -240,11 +261,11 @@ function parseAnswersFromMarkdown(markdownText) {
   const sections = parseSectionsFromTokens(tokens);
   const type = ((sections.get('Type') || []).map(t => t.raw || t.text).join('\n') || '').trim();
   const responsesSection = sections.get('Responses') || [];
-  
+
   // Parse responses to extract selected answers
   const responsesText = responsesSection.map(t => t.raw || t.text || '').join('\n');
   const answers = {};
-  
+
   if (/^multiple choice$/i.test(type)) {
     // Parse MCQ responses: "Selected Answer: D" or "Selected Answer: B, D"
     // Also parse explanations if present: "Explanation: ..." (comes after Result line)
@@ -267,7 +288,7 @@ function parseAnswersFromMarkdown(markdownText) {
         }
       }
     });
-    
+
     // Then parse selected answers
     const responseRegex = /(\d+)\.\s*\*\*[^*]+\*\*[\s\S]*?Selected Answer:\s*([^\n]+)/g;
     let match;
@@ -362,13 +383,13 @@ function buildActivityFromMarkdown(markdownText) {
     const fibTokens = sections.get('Markdown With Blanks') || [];
     const fibMarkdown = fibTokens.map(t => t.raw || t.text || '').join('\n').trim();
     const suggested = readListItems(sections.get('Suggested Answers'));
-    
+
     // Split the content into prompt and fill-in-the-blanks content
     const lines = fibMarkdown.split(/\r?\n/);
     let promptLines = [];
     let contentLines = [];
     let foundBlockquote = false;
-    
+
     for (const line of lines) {
       if (/^\s*>/.test(line)) {
         foundBlockquote = true;
@@ -384,10 +405,10 @@ function buildActivityFromMarkdown(markdownText) {
         }
       }
     }
-    
+
     const prompt = promptLines.join('\n').trim();
     const content = contentLines.join('\n').trim();
-    
+
     const blanks = [];
     let idx = 0;
     // Replace blank tokens with actual HTML spans that will be preserved by the markdown renderer
@@ -457,7 +478,7 @@ function buildActivityFromMarkdown(markdownText) {
     // Parse MCQ with support for multiple questions
     const questions = [];
     const allTokens = Lexer.lex(markdownText);
-    
+
     let currentQuestion = null;
     let currentSection = null;
     let questionBuffer = [];
@@ -475,7 +496,7 @@ function buildActivityFromMarkdown(markdownText) {
         s = (s * 9301 + 49297) % 233280;
         return s / 233280;
       }
-      
+
       // Fisher-Yates shuffle with seeded random
       const shuffled = [...array];
       for (let i = shuffled.length - 1; i > 0; i--) {
@@ -484,7 +505,7 @@ function buildActivityFromMarkdown(markdownText) {
       }
       return shuffled;
     }
-    
+
     // Generate seed from question text and all option texts
     function generateSeed(questionText, options) {
       const allText = questionText + options.map(opt => opt.text + opt.label).join('');
@@ -496,14 +517,14 @@ function buildActivityFromMarkdown(markdownText) {
       }
       return Math.abs(hash);
     }
-    
+
     function processQuestion() {
       if (!currentQuestion || questionBuffer.length === 0) return;
-      
+
       // Parse options from question text
       const questionText = questionBuffer.map(t => t.raw || t.text || '').join('\n').trim();
       const options = [];
-      
+
       // Extract options (A., B., C., etc.)
       const optionRegex = /^([A-Z])\.\s*(.+)$/gm;
       let match;
@@ -512,10 +533,10 @@ function buildActivityFromMarkdown(markdownText) {
         const label = match[1];
         const text = match[2].trim();
         optionMap.set(label, text);
-        
+
         // Parse markdown to HTML for rendering (supports images, bold, etc.)
         const textHtml = renderMarkdown(text);
-        
+
         options.push({
           label: label,
           text: text, // Keep raw text for backward compatibility
@@ -523,23 +544,23 @@ function buildActivityFromMarkdown(markdownText) {
           correct: false // Will be set from Suggested Answers
         });
       }
-      
+
       // Extract question text without options
       const questionTextOnly = questionText.replace(/^[A-Z]\.\s*.+$/gm, '').trim();
-      
+
       // Store raw markdown text (for answer.md generation)
       currentQuestion.text = questionTextOnly || questionText;
-      
+
       // Parse markdown to HTML for rendering (supports multiple paragraphs, blockquotes, etc.)
       if (currentQuestion.text) {
         currentQuestion.textHtml = renderMarkdown(currentQuestion.text);
       } else {
         currentQuestion.textHtml = '';
       }
-      
+
       currentQuestion.options = options;
     }
-    
+
     function processExplainAnswer() {
       if (!currentQuestion) return;
       const raw = explainAnswerBuffer.map(t => t.raw || t.text || '').join('\n').trim();
@@ -551,20 +572,20 @@ function buildActivityFromMarkdown(markdownText) {
         delete currentQuestion.explainAnswerLabel;
       }
     }
-    
+
     function processQuestionOptions() {
       if (!currentQuestion) return;
-      
+
       // Parse question options section
       const optionsText = questionOptionsBuffer.map(t => t.raw || t.text || '').join('\n').trim().toLowerCase();
-      
+
       // Check for shuffle option
       if (optionsText.includes('shuffle=false') || optionsText.includes('don\'t shuffle') || optionsText.includes('dont shuffle') || optionsText === 'no shuffle') {
         currentQuestion.shuffleOptions = false;
       } else {
         currentQuestion.shuffleOptions = true; // Default to shuffling
       }
-      
+
       // Check for multi-select mode (any vs all)
       // Default is 'all' - must select all correct answers
       // 'any' means any correct answer is sufficient
@@ -574,10 +595,10 @@ function buildActivityFromMarkdown(markdownText) {
         currentQuestion.multiSelectMode = 'all'; // Default
       }
     }
-    
+
     function processAnswers() {
       if (!currentQuestion) return;
-      
+
       // Process explain answer first if buffer exists (even if no answers yet)
       if (explainAnswerBuffer.length > 0) {
         processExplainAnswer();
@@ -585,7 +606,7 @@ function buildActivityFromMarkdown(markdownText) {
         currentQuestion.explainAnswer = false;
         delete currentQuestion.explainAnswerLabel;
       }
-      
+
       // Process question options if buffer exists
       if (questionOptionsBuffer.length > 0) {
         processQuestionOptions();
@@ -593,12 +614,12 @@ function buildActivityFromMarkdown(markdownText) {
         currentQuestion.shuffleOptions = true; // Default to shuffling
         currentQuestion.multiSelectMode = 'all'; // Default multi-select mode
       }
-      
+
       // Process answers if buffer has content
       if (answerBuffer.length > 0) {
         const answerItems = readListItems(answerBuffer);
         const correctAnswers = new Set();
-        
+
         answerItems.forEach(item => {
           const trimmed = item.trim();
           // Match patterns like "A", "A - Correct", "B - Correct", etc.
@@ -610,26 +631,26 @@ function buildActivityFromMarkdown(markdownText) {
             }
           }
         });
-        
+
         // Mark correct options
         currentQuestion.options.forEach(opt => {
           opt.correct = correctAnswers.has(opt.label);
         });
-        
+
         // Determine if multi-select
         currentQuestion.isMultiSelect = correctAnswers.size > 1;
       }
-      
+
       // Shuffle options only if shuffleOptions is true (default behavior)
       if (currentQuestion.shuffleOptions !== false) {
         const seed = generateSeed(currentQuestion.text, currentQuestion.options);
         currentQuestion.options = seededShuffle(currentQuestion.options, seed);
       }
-      
+
       // Add to questions array
       questions.push(currentQuestion);
     }
-    
+
     // Parse tokens sequentially
     for (const token of allTokens) {
       if (token.type === 'paragraph') {
@@ -637,13 +658,13 @@ function buildActivityFromMarkdown(markdownText) {
         const m = text.match(/^__([^_]+)__\s*$/);
         if (m) {
           const sectionName = m[1].trim();
-          
+
           if (sectionName === 'Practice Question') {
             // Process previous question/answers if any
             if (currentQuestion) {
               processAnswers();
             }
-            
+
             // Start new question
             const nameFromBuffer = questionNameBuffer.map(t => t.raw || t.text || '').join('\n').trim();
             questionNameBuffer = [];
@@ -735,12 +756,12 @@ function buildActivityFromMarkdown(markdownText) {
         explainAnswerBuffer.push(token);
       }
     }
-    
+
     // Process last question and answers
     if (currentQuestion) {
       processAnswers();
     }
-    
+
     if (questions.length === 0) {
       throw new Error('No MCQ questions found');
     }
@@ -760,13 +781,13 @@ function buildActivityFromMarkdown(markdownText) {
     const matchingTokens = sections.get('Markdown With Blanks') || [];
     const matchingMarkdown = matchingTokens.map(t => t.raw || t.text || '').join('\n').trim();
     const suggested = readListItems(sections.get('Suggested Answers'));
-    
+
     // Split the content into prompt and matching items
     const lines = matchingMarkdown.split(/\r?\n/);
     let promptLines = [];
     let itemLines = [];
     let foundBlockquote = false;
-    
+
     for (const line of lines) {
       if (/^\s*>/.test(line)) {
         foundBlockquote = true;
@@ -782,9 +803,9 @@ function buildActivityFromMarkdown(markdownText) {
         }
       }
     }
-    
+
     const prompt = promptLines.join('\n').trim();
-    
+
     const items = [];
     let idx = 0;
     // Parse each blockquote line as a separate item
@@ -794,13 +815,13 @@ function buildActivityFromMarkdown(markdownText) {
         const itemLine = line.replace(/^\s*>\s?/, '').trim();
         const blankMatch = itemLine.match(/\[\[blank:([^\]]+)\]\]/i);
         if (!blankMatch) continue;
-        
+
         const answer = String(blankMatch[1]).trim();
         const textBeforeBlank = itemLine.replace(/\[\[blank:[^\]]+\]\]/gi, '').trim();
-        
+
         // Render text without blank to HTML
         const textHtml = renderMarkdown(textBeforeBlank);
-        
+
         items.push({
           index: idx++,
           text: textBeforeBlank,
@@ -809,7 +830,7 @@ function buildActivityFromMarkdown(markdownText) {
         });
       }
     }
-    
+
     // Build choices preserving duplicates from Suggested Answers, and ensure
     // at least as many copies of each correct answer as there are blanks.
     const suggestedTrimmed = suggested.map(s => s.trim()).filter(Boolean);
@@ -827,7 +848,7 @@ function buildActivityFromMarkdown(markdownText) {
       const have = suggestedCounts.get(k) || 0;
       for (let i = have; i < req; i++) choices.push(k);
     });
-    
+
     // Shuffle choices using deterministic shuffle
     let s = (markdownText.length || 1337) % 2147483647 || 1337;
     function rand() { s = (s * 48271) % 2147483647; return s / 2147483647; }
@@ -835,7 +856,7 @@ function buildActivityFromMarkdown(markdownText) {
       const j = Math.floor(rand() * (i + 1));
       [choices[i], choices[j]] = [choices[j], choices[i]];
     }
-    
+
     // Render markdown to HTML for prompt
     const promptHtml = prompt ? renderMarkdown(prompt) : '';
 
@@ -864,21 +885,21 @@ function buildActivityFromMarkdown(markdownText) {
     // Parse Text Input with support for multiple questions
     const questions = [];
     const allTokens = Lexer.lex(markdownText);
-    
+
     let currentQuestion = null;
     let currentSection = null;
     let questionBuffer = [];
     let answerBuffer = [];
     let headingBuffer = [];
     let questionNameBuffer = [];
-    
+
     function processQuestion() {
       if (!currentQuestion || questionBuffer.length === 0) return;
-      
+
       // Extract question text
       const questionText = questionBuffer.map(t => t.raw || t.text || '').join('\n').trim();
       currentQuestion.text = questionText;
-      
+
       // Parse markdown to HTML for rendering (supports LaTeX, images, bold, etc.)
       if (currentQuestion.text) {
         currentQuestion.textHtml = renderMarkdown(currentQuestion.text);
@@ -886,12 +907,12 @@ function buildActivityFromMarkdown(markdownText) {
         currentQuestion.textHtml = '';
       }
     }
-    
+
     function processAnswers() {
       if (!currentQuestion || answerBuffer.length === 0) return;
-      
+
       const answerItems = readListItems(answerBuffer);
-      
+
       // For text-input, support multiple correct answers.
       if (answerItems.length > 0) {
         const parsed = parseTextInputAnswerItems(answerItems);
@@ -899,11 +920,11 @@ function buildActivityFromMarkdown(markdownText) {
         currentQuestion.correctAnswer = parsed.correctAnswer;
         currentQuestion.validation = parsed.validation;
       }
-      
+
       // Add to questions array
       questions.push(currentQuestion);
     }
-    
+
     // Parse tokens sequentially
     for (const token of allTokens) {
       if (token.type === 'paragraph') {
@@ -911,7 +932,7 @@ function buildActivityFromMarkdown(markdownText) {
         const m = text.match(/^__([^_]+)__\s*$/);
         if (m) {
           const sectionName = m[1].trim();
-          
+
           if (sectionName === 'Practice Question') {
             // Process previous question/answers if any
             if (currentQuestion) {
@@ -961,7 +982,7 @@ function buildActivityFromMarkdown(markdownText) {
           }
         }
       }
-      
+
       if (currentSection === 'questionName') {
         questionNameBuffer.push(token);
       } else if (currentSection === 'question' && currentQuestion) {
@@ -972,16 +993,16 @@ function buildActivityFromMarkdown(markdownText) {
         headingBuffer.push(token);
       }
     }
-    
+
     // Process last question and answers
     if (currentQuestion) {
       processAnswers();
     }
-    
+
     if (questions.length === 0) {
       throw new Error('No text input questions found');
     }
-    
+
     // Process heading section if present
     let heading = null;
     if (headingBuffer.length > 0) {
@@ -990,7 +1011,7 @@ function buildActivityFromMarkdown(markdownText) {
         heading = { markdown: headingText, html: renderMarkdown(headingText) };
       }
     }
-    
+
     const activity = { type, question: null, textInput: { questions, heading } };
     attachSideContent(activity, sections);
     const side = activity.content || null;
@@ -1136,12 +1157,62 @@ function buildActivityFromMarkdown(markdownText) {
   return attachSideContent({ type, question, labels: { left, right }, items }, sections);
 }
 
+function simUpstreamPath(pathname) {
+  if (pathname === SIM_MOUNT_PATH) return '/';
+  const prefix = `${SIM_MOUNT_PATH}/`;
+  if (pathname.startsWith(prefix)) return pathname.slice(SIM_MOUNT_PATH.length) || '/';
+  return pathname;
+}
+
+function shouldProxyToSim(pathname) {
+  if (!SIM_ORIGIN) return false;
+  if (pathname === SIM_MOUNT_PATH || pathname.startsWith(`${SIM_MOUNT_PATH}/`)) return true;
+  for (const entry of SIM_ROOT_PROXY_PATHS) {
+    if (entry.endsWith('/')) {
+      if (pathname.startsWith(entry)) return true;
+    } else if (pathname === entry || pathname.startsWith(`${entry}/`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function proxyToSim(req, res, pathname) {
+  const subpath = simUpstreamPath(pathname);
+  const target = new URL(subpath, SIM_ORIGIN);
+  const options = {
+    hostname: target.hostname,
+    port: target.port || (target.protocol === 'https:' ? 443 : 80),
+    path: target.pathname + target.search,
+    method: req.method,
+    headers: { ...req.headers, host: target.host }
+  };
+  const proxyReq = http.request(options, (proxyRes) => {
+    res.writeHead(proxyRes.statusCode, proxyRes.headers);
+    proxyRes.pipe(res);
+  });
+  proxyReq.on('error', () => {
+    res.writeHead(502, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Simulation not running on ' + SIM_ORIGIN);
+  });
+  if (req.method === 'GET' || req.method === 'HEAD') {
+    proxyReq.end();
+  } else {
+    req.pipe(proxyReq);
+  }
+}
+
 // Store active WebSocket connections
 const clients = new Set();
 
 const server = http.createServer((req, res) => {
   const urlObj = new URL(req.url, 'http://localhost');
   let pathname = decodeURIComponent(urlObj.pathname || '/');
+
+  if (shouldProxyToSim(pathname)) {
+    proxyToSim(req, res, pathname);
+    return;
+  }
 
   // Examples mode: shell at /, activity app in iframe at /play
   if (EXAMPLES_MODE && pathname === '/') {
@@ -1203,13 +1274,13 @@ const server = http.createServer((req, res) => {
       try {
         const data = JSON.parse(body);
         const markdown = data.markdown || '';
-        
+
         // Ensure directory exists
         const dir = path.dirname(EDIT_FILE_PATH);
         if (!fs.existsSync(dir)) {
           fs.mkdirSync(dir, { recursive: true });
         }
-        
+
         fs.writeFile(EDIT_FILE_PATH, markdown, 'utf8', (err) => {
           if (err) {
             respondJson(res, 500, { error: 'Failed to save file' });
@@ -1311,7 +1382,7 @@ const server = http.createServer((req, res) => {
   if (pathname === '/api/answers') {
     const answerFile = path.join(DATA_DIR, 'answer.md');
     const activityFile = path.join(DATA_DIR, 'question.md');
-    
+
     // Read both answer.md and question.md to map result indices to question IDs
     fs.readFile(answerFile, 'utf8', (err, answerData) => {
       if (err) {
@@ -1319,7 +1390,7 @@ const server = http.createServer((req, res) => {
         respondJson(res, 200, { answers: null, type: null, explanations: null });
         return;
       }
-      
+
       // Also read activity to map indices to question IDs
       fs.readFile(activityFile, 'utf8', (err, activityData) => {
         if (err) {
@@ -1333,11 +1404,11 @@ const server = http.createServer((req, res) => {
           }
           return;
         }
-        
+
         try {
           const parsed = parseAnswersFromMarkdown(answerData);
           let { answers, type, explanations } = parsed;
-          
+
           // For MCQ, map result indices to question IDs
           if (/^multiple choice$/i.test(type) && explanations) {
             const activity = buildActivityFromMarkdown(activityData);
@@ -1356,7 +1427,7 @@ const server = http.createServer((req, res) => {
               explanations = mappedExplanations;
             }
           }
-          
+
           respondJson(res, 200, { answers, type, explanations: explanations || null });
         } catch (e) {
           respondJson(res, 500, { error: 'Failed to parse answers' });
@@ -1374,9 +1445,9 @@ const server = http.createServer((req, res) => {
         client.send(JSON.stringify({ type: 'validate' }));
       }
     });
-    
-    respondJson(res, 200, { 
-      status: 'success', 
+
+    respondJson(res, 200, {
+      status: 'success',
       message: 'Validation message sent to all connected clients',
       clientCount: clients.size
     });
@@ -1394,7 +1465,7 @@ const server = http.createServer((req, res) => {
         const data = JSON.parse(body);
         const markdown = data.markdown || '';
         const html = renderMarkdown(markdown);
-        
+
         // Return HTML wrapped in a proper document with styles
         const fullHtml = `<!DOCTYPE html>
 <html lang="en">
@@ -1447,8 +1518,8 @@ const server = http.createServer((req, res) => {
   </script>
 </body>
 </html>`;
-        
-        res.writeHead(200, { 
+
+        res.writeHead(200, {
           'Content-Type': 'text/html; charset=utf-8',
           'Cache-Control': 'no-store'
         });
@@ -1472,7 +1543,7 @@ const server = http.createServer((req, res) => {
         const answerFile = path.join(DATA_DIR, 'answer.md');
         const reportFile = path.join(DATA_DIR, 'report.md');
         const scoreFile = path.join(DATA_DIR, 'score.json');
-        
+
         // Format results as markdown
         const activity = data.activity;
 
@@ -1481,16 +1552,16 @@ const server = http.createServer((req, res) => {
         ).length;
 
         const validateLaterCount = countValidateLaterTextInputResults(activity, data.results);
-        
+
         // Total count excludes "validate-later" questions from scoring
         const totalCount = data.results.length - validateLaterCount;
-        
+
         let markdown = '';
-        
+
         // Include original activity details
         if (activity) {
           markdown += `__Type__\n\n${activity.type}\n\n`;
-          
+
           // Add results section with summary
           let summaryText = `${correctCount}/${totalCount} correct`;
           if (validateLaterCount > 0) {
@@ -1498,7 +1569,7 @@ const server = http.createServer((req, res) => {
           }
           markdown += `__Summary__\n\n${summaryText}\n\n`;
           markdown += '__Responses__\n\n';
-          
+
           data.results.forEach((result, index) => {
             markdown += `${index + 1}. **${result.text}**\n`;
             markdown += `   - Selected Answer: ${result.selected || 'No answer selected'}\n`;
@@ -1526,7 +1597,7 @@ const server = http.createServer((req, res) => {
             } else {
               markdown += `   - Result: ${isCorrect ? '✓ Correct' : '✗ Incorrect'}\n`;
             }
-            
+
             // Add explanation if present (for MCQ questions with explainAnswer enabled)
             if (result.explanation) {
               markdown += `   - Explanation: ${result.explanation}\n`;
@@ -1669,7 +1740,7 @@ const server = http.createServer((req, res) => {
             if (activity.question) {
               markdown += `__Practice Question__\n\n${activity.question}\n\n`;
             }
-            
+
             if (activity.labels) {
               markdown += `__Labels__\n\n`;
               if (/^sort into boxes$/i.test(activity.type)) {
@@ -1682,7 +1753,7 @@ const server = http.createServer((req, res) => {
             }
           }
         }
-        
+
         const reportMarkdown = buildActivityReportMarkdown(activity, data.results || []);
         const scoreJson = JSON.stringify(buildScoreJson(activity, data.results || []), null, 2);
 
@@ -1767,13 +1838,13 @@ wss.on('connection', (ws, req) => {
   // Add new client to the Set
   clients.add(ws);
   console.log('WebSocket connection established, total clients:', clients.size);
-  
+
   // Handle WebSocket connection close
   ws.on('close', () => {
     clients.delete(ws);
     console.log('WebSocket connection closed, remaining clients:', clients.size);
   });
-  
+
   // Handle errors
   ws.on('error', (error) => {
     console.error('WebSocket error:', error);

--- a/sim-server.js
+++ b/sim-server.js
@@ -1,0 +1,164 @@
+/**
+ * Minimal "Hello World" simulation server used as a test harness for split-screen mode.
+ * Started automatically by server.js when --examples flag is used.
+ * Can also be run standalone: node sim-server.js [port]
+ */
+
+const http = require('http');
+
+const PORT = parseInt(process.env.SIM_PORT || process.argv[2] || '8080', 10);
+
+const HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hello World Simulation</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      gap: 2rem;
+    }
+
+    .badge {
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      padding: 0.25rem 0.75rem;
+      border-radius: 999px;
+      background: #1e3a5f;
+      color: #60a5fa;
+      border: 1px solid #2563eb44;
+    }
+
+    h1 {
+      font-size: clamp(1.8rem, 5vw, 3rem);
+      font-weight: 800;
+      background: linear-gradient(135deg, #60a5fa, #a78bfa, #f472b6);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      text-align: center;
+      line-height: 1.1;
+    }
+
+    p {
+      color: #94a3b8;
+      font-size: 1rem;
+      text-align: center;
+      max-width: 360px;
+      line-height: 1.6;
+    }
+
+    .card {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 1.5rem;
+      width: 100%;
+      max-width: 360px;
+    }
+
+    .card-title {
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #64748b;
+      margin-bottom: 1rem;
+    }
+
+    .stat-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.5rem 0;
+      border-bottom: 1px solid #1e293b;
+      font-size: 0.875rem;
+    }
+    .stat-row:last-child { border-bottom: none; }
+    .stat-label { color: #94a3b8; }
+    .stat-value { font-weight: 600; color: #e2e8f0; font-family: monospace; }
+    .stat-value.ok { color: #4ade80; }
+
+    .pulse {
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: #4ade80;
+      box-shadow: 0 0 0 0 #4ade8080;
+      animation: pulse 2s infinite;
+      margin-right: 6px;
+      vertical-align: middle;
+    }
+    @keyframes pulse {
+      0%   { box-shadow: 0 0 0 0 #4ade8080; }
+      70%  { box-shadow: 0 0 0 8px #4ade8000; }
+      100% { box-shadow: 0 0 0 0 #4ade8000; }
+    }
+
+    #clock { font-family: monospace; color: #60a5fa; }
+  </style>
+</head>
+<body>
+  <span class="badge">&#9679; Simulation Running</span>
+
+  <h1>Hello World<br/>Simulation</h1>
+
+  <p>
+    This is a dummy simulation served by <code>sim-server.js</code>.
+    It proves split-screen reverse-proxy is working end-to-end.
+  </p>
+
+  <div class="card">
+    <div class="card-title">Runtime info</div>
+    <div class="stat-row">
+      <span class="stat-label">Status</span>
+      <span class="stat-value ok"><span class="pulse"></span>Online</span>
+    </div>
+    <div class="stat-row">
+      <span class="stat-label">Port</span>
+      <span class="stat-value">${PORT}</span>
+    </div>
+    <div class="stat-row">
+      <span class="stat-label">Proxied under</span>
+      <span class="stat-value">/sim/</span>
+    </div>
+    <div class="stat-row">
+      <span class="stat-label">Local time</span>
+      <span class="stat-value" id="clock">—</span>
+    </div>
+  </div>
+
+  <script>
+    const clock = document.getElementById('clock');
+    function tick() {
+      clock.textContent = new Date().toLocaleTimeString();
+    }
+    tick();
+    setInterval(tick, 1000);
+  </script>
+</body>
+</html>`;
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' });
+  res.end(HTML);
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  // Signal to parent that we're ready (used by server.js spawn logic)
+  process.stdout.write(`sim-server listening on http://127.0.0.1:${PORT}\n`);
+});


### PR DESCRIPTION
This PR implements changes that are required to host simulation on /sim/ and put it into the split screen. All types of questions work except matching, but matching doesn't work without these changes as well.

The changes are tested on staging by cloning this repository in the `setup.sh` and switching to this branch. Questions for test:
1. Simulation + quiz: https://codesignal.dev/learn/course/3242/unit/1/practice/1
2. Simulation + input-text: https://codesignal.dev/learn/course/3242/unit/1/practice/2
3. No split screen (backward compatibility test): https://codesignal.dev/learn/course/3242/unit/1/practice/3

How to test it yourself:

1. **Pick any simulation-as-content.** Any CodeSignal `learn_*` repository

2. **Create a base task with a `setup.sh` that:**

   a. Downloads the simulation release as usual.

   b. Starts the simulation on a port **other than 3000** (the activity server owns 3000). Cosmo Activities will reverse-proxy it under `/sim/`.

      > Some simulations hard-code port 3000 in their production server. If yours does, patch it in `setup.sh` before launch. For example, CosmoPlot used to do this, but it is already updated and accepts `PORT` and does not need this patch.

   c. Exports `SIM_ORIGIN` pointing at the simulation's full origin:

      ```bash
      export SIM_ORIGIN=http://127.0.0.1:3001
      ```

      Optional: if your simulation requests root-absolute paths that aren't covered by the default list (`/assets/`, `/configs/`, `/api/logs`), also export `SIM_ROOT_PROXY_PATHS` with a comma-separated list.
  
   d. Fetches Cosmo Activities. As changes are not in any release yet, for now it should use git clone and switch to this branch.

   e. Launches Cosmo Activities as usual (on the default port 3000). The order matters only in that the simulation should already be reachable when the user opens the page; starting it before the activity server is the safest.

3. **Author a question that uses `/sim/` as side content.** In `.codesignal/question.md`, add a `__Content__` section with a site-relative URL:

   ```markdown
   __Type__

   Multiple Choice

   __Content__

   /sim/ [contentWidth: 50%]

   __Practice Question__

   ...

Example of the setup.sh and run_solution.sh for this mode can be found [here](https://engine.codesignal.com/task-view/ihALzxswLK2eg8Dmt)