### PR TITLE
Fix number input spinner overlap with unit labels in text-input

### DIFF
--- a/public/modules/text-input.css
+++ b/public/modules/text-input.css
@@ -195,8 +195,8 @@
 
 .text-input-field-wrapper-units .text-input-field[type="number"] {
   padding-right: calc(
-    var(--UI-Spacing-spacing-ms, 16px) + 2ch + var(--UI-Spacing-spacing-xs, 8px) +
-    var(--text-input-units-spinner-width)
+    var(--UI-Spacing-spacing-ms, 16px) + 2ch + var(--UI-Spacing-spacing-xs, 8px)
+    + var(--text-input-units-spinner-width)
   );
 }
 

--- a/public/modules/text-input.css
+++ b/public/modules/text-input.css
@@ -165,6 +165,11 @@
   box-sizing: border-box;
 }
 
+.text-input-field-wrapper-units {
+  /* Room for native number-input spin buttons so they sit left of the unit label */
+  --text-input-units-spinner-width: 1.25rem;
+}
+
 .text-input-field-wrapper-units::after {
   content: attr(data-units);
   position: absolute;
@@ -182,6 +187,17 @@
 .text-input-field-wrapper-units .text-input-field {
   padding-right: calc(var(--UI-Spacing-spacing-ms, 16px) + 2ch + var(--UI-Spacing-spacing-xs, 8px));
   box-sizing: border-box;
+}
+
+.text-input-field-wrapper-units:has(.text-input-field[type="number"])::after {
+  right: calc(var(--UI-Spacing-spacing-ms, 16px) + var(--text-input-units-spinner-width));
+}
+
+.text-input-field-wrapper-units .text-input-field[type="number"] {
+  padding-right: calc(
+    var(--UI-Spacing-spacing-ms, 16px) + 2ch + var(--UI-Spacing-spacing-xs, 8px) +
+    var(--text-input-units-spinner-width)
+  );
 }
 
 .text-input-field {


### PR DESCRIPTION
Reserve space for native spin buttons so unit labels sit to their left on numeric-with-units fields.

Before this fix, this is what it looked like: 
<img width="798" height="451" alt="image" src="https://github.com/user-attachments/assets/0f97b5b9-1bd4-4abc-b810-cac8b1c6535c" />

Moved arrows over to give space for the units (if applicable) 
