### PR TITLE
fix(matching): Raise Best response placeholder contrast to WCAG AA

### DIFF
--- a/public/modules/matching.css
+++ b/public/modules/matching.css
@@ -8,7 +8,7 @@
   --Colors-Learn-Practice-Selection-Area-Border-Active: var(--Colors-Primary-Default);
   --Colors-Learn-Practice-Selection-Area-Border-Matched: var(--Colors-Stroke-Default);
   --Colors-Learn-Practice-Selection-Area-Background: var(--Colors-Backgrounds-Main-Top);
-  --Colors-Learn-Practice-Selection-Area-Placeholder: var(--Colors-Text-Body-Lighter);
+  --Colors-Learn-Practice-Selection-Area-Placeholder: var(--Colors-Text-Body-Light);
   --Colors-Learn-Practice-Choice-Background-Used: var(--Colors-Backgrounds-Main-Light);
   --Colors-Learn-Practice-Choice-Label-Used: var(--Colors-Text-Body-Light);
   --Colors-Learn-Practice-Interactive-Choice-Main-Background: var(--Colors-Base-Accent-Sky-Blue-100);
@@ -24,7 +24,7 @@
     --Colors-Learn-Practice-Selection-Area-Border-Active: var(--Colors-Primary-Default);
     --Colors-Learn-Practice-Selection-Area-Border-Matched: var(--Colors-Stroke-Default);
     --Colors-Learn-Practice-Selection-Area-Background: var(--Colors-Backgrounds-Main-Light);
-    --Colors-Learn-Practice-Selection-Area-Placeholder: var(--Colors-Text-Body-Light);
+    --Colors-Learn-Practice-Selection-Area-Placeholder: var(--Colors-Text-Body-Default);
     --Colors-Learn-Practice-Choice-Background-Used: var(--Colors-Backgrounds-Main-Medium);
     --Colors-Learn-Practice-Choice-Label-Used: var(--Colors-Text-Body-Medium);
     --Colors-Learn-Practice-Interactive-Choice-Main-Background: var(--Colors-Base-Accent-Sky-Blue-700);
@@ -173,7 +173,7 @@
 
 .matching-selection-area.empty {
   /* Uses .body-xxsmall class from design system */
-  color: var(--Colors-Text-Body-Lighter);
+  color: var(--Colors-Learn-Practice-Selection-Area-Placeholder);
   background: transparent;
 }
 


### PR DESCRIPTION
## Summary

Fixes a WCAG 1.4.3 AA color-contrast failure on the **"Best response"** placeholder in the Matching activity, flagged by the HBP accessibility audit (CodeSignal/codesignal#40462).

The empty selection area (`.matching-selection-area.empty`) hardcoded `--Colors-Text-Body-Lighter`, rendering Neutral‑800 `#808AA5` on the white card ≈ **3.4:1** (audit reported 3.2:1), below the 4.5:1 minimum for 13px normal-weight text. Dark mode was worse (~2.7:1).

## Changes

- Route `.empty` through the existing semantic token `--Colors-Learn-Practice-Selection-Area-Placeholder` instead of hardcoding the lowest-contrast color.
- Light mode: `Body-Lighter` → `Body-Light` (Neutral‑900 `#66718F` on white ≈ **4.9:1** ✓)
- Dark mode: `Body-Light` → `Body-Default` (Neutral‑450 `#C1C7D7` on `#26314C` ≈ **7.6:1** ✓)

Placeholder stays visually muted relative to filled answers; no layout changes.

## Test plan

- [x] Light mode: "Best response" placeholder is legible and passes AA (≥ 4.5:1)
- [x] Dark mode: placeholder passes AA (≥ 4.5:1)
- [x] Placeholder still reads as muted vs. a filled/matched answer
- [x] Re-run accessibility scanner on the Building Trust and Inclusion page

Refs CodeSignal/codesignal#40462

Made with [Cursor](https://cursor.com)