### PR TITLE
fix(mcq): keep A/B/C/D in display order for screen readers

### DIFF
--- a/public/modules/mcq.js
+++ b/public/modules/mcq.js
@@ -29,6 +29,30 @@ export function initMcq({
   const elMcq = document.getElementById('mcq');
   const elQuestions = document.getElementById('mcq-questions');
 
+  // Options carry two labels: `label` is the authored source letter (A/B/C/D tied to
+  // a specific answer text, used for grading and report/answer output) and
+  // `displayLabel` is the letter shown to the learner after shuffling. Older activity
+  // payloads (e.g. editor previews) may omit `displayLabel`, so fall back to `label`.
+  function labelForDisplay(option) {
+    return option.displayLabel || option.label;
+  }
+
+  // Translate persisted/graded source labels into the display labels the client tracks.
+  function sourceToDisplay(question, sourceLabels) {
+    return (sourceLabels || []).map(sl => {
+      const opt = question.options.find(o => o.label === sl);
+      return opt ? labelForDisplay(opt) : sl;
+    });
+  }
+
+  // Translate the display labels the client tracks back into authored source labels.
+  function displayToSource(question, displayLabels) {
+    return (displayLabels || []).map(dl => {
+      const opt = question.options.find(o => labelForDisplay(o) === dl);
+      return opt ? opt.label : dl;
+    });
+  }
+
   // Optional heading (shared pattern with Text Input)
   const hasHeading = mcq.heading && (mcq.heading.html || mcq.heading.markdown);
   if (hasHeading) {
@@ -56,9 +80,11 @@ export function initMcq({
   // Initialize selected answers from persisted answers if available
   mcq.questions.forEach(q => {
     if (persistedAnswers && persistedAnswers[q.id] !== undefined) {
-      selectedAnswers[q.id] = Array.isArray(persistedAnswers[q.id]) 
-        ? persistedAnswers[q.id] 
+      const raw = Array.isArray(persistedAnswers[q.id])
+        ? persistedAnswers[q.id]
         : [persistedAnswers[q.id]];
+      // Persisted answers are stored as source labels; track them as display labels.
+      selectedAnswers[q.id] = sourceToDisplay(q, raw);
     } else {
       selectedAnswers[q.id] = [];
     }
@@ -106,6 +132,7 @@ export function initMcq({
     
     // Create options
     question.options.forEach((option, optIdx) => {
+      const displayLabel = labelForDisplay(option);
       const optionEl = document.createElement('label');
       // Apply design system classes to the option label
       optionEl.className = question.isMultiSelect 
@@ -115,9 +142,9 @@ export function initMcq({
       const input = document.createElement('input');
       input.type = question.isMultiSelect ? 'checkbox' : 'radio';
       input.name = `question-${question.id}`;
-      input.value = option.label;
+      input.value = displayLabel;
       input.id = `q${question.id}-opt${optIdx}`;
-      input.setAttribute('aria-label', `Option ${option.label}: ${option.text}`);
+      input.setAttribute('aria-label', `Option ${displayLabel}: ${option.text}`);
       
       const optionText = document.createElement('div');
       optionText.className = 'mcq-option-text body-large markdown-content';
@@ -132,7 +159,7 @@ export function initMcq({
       
       const optionLabel = document.createElement('span');
       optionLabel.className = 'mcq-option-label';
-      optionLabel.textContent = option.label + '.';
+      optionLabel.textContent = displayLabel + '.';
       
       // Create option card structure matching Figma design
       const optionCard = document.createElement('div');
@@ -175,8 +202,8 @@ export function initMcq({
         optionCard.appendChild(textWrapper);
       }
       
-      // Apply persisted answers if available
-      if (selectedAnswers[question.id] && selectedAnswers[question.id].includes(option.label)) {
+      // Apply persisted answers if available (tracked as display labels)
+      if (selectedAnswers[question.id] && selectedAnswers[question.id].includes(displayLabel)) {
         input.checked = true;
       }
       
@@ -189,7 +216,7 @@ export function initMcq({
       input.addEventListener('change', () => {
         // Clear validation when user changes any value
         clearValidation();
-        updateSelection(question.id, option.label, input.checked);
+        updateSelection(question.id, displayLabel, input.checked);
         
         // For radio questions, scroll to the next question (no "focus" / de-emphasis UI)
         // Only if there are multiple questions AND explainAnswer is not enabled
@@ -383,7 +410,8 @@ export function initMcq({
     
     // Check each question and mark incorrect ones
     mcq.questions.forEach(q => {
-      const selected = selectedAnswers[q.id] || [];
+      // Compare in authored source-label space so highlighting matches server grading.
+      const selected = displayToSource(q, selectedAnswers[q.id] || []);
       const correct = q.options.filter(opt => opt.correct).map(opt => opt.label);
       
       let isCorrect = false;
@@ -413,7 +441,9 @@ export function initMcq({
   
   function updateResultsAndPost() {
     state.results = mcq.questions.map((q, idx) => {
-      const selected = selectedAnswers[q.id] || [];
+      // Persist/post answers as authored source labels so report.md, score.json,
+      // answer.md, and reload all stay in the original A/B/C/D space.
+      const selected = displayToSource(q, selectedAnswers[q.id] || []);
       const correct = q.options.filter(opt => opt.correct).map(opt => opt.label);
       
       let isCorrect = false;

--- a/server.js
+++ b/server.js
@@ -695,6 +695,13 @@ function buildActivityFromMarkdown(markdownText) {
         currentQuestion.options = seededShuffle(currentQuestion.options, seed);
       }
 
+      // Assign a display label (A, B, C, ...) by final display position so screen
+      // readers announce options in order even after shuffling. `label` stays the
+      // authored source letter used for grading and report/answer output.
+      currentQuestion.options.forEach((opt, i) => {
+        opt.displayLabel = String.fromCharCode(65 + i);
+      });
+
       // Add to questions array
       questions.push(currentQuestion);
     }
@@ -1795,13 +1802,18 @@ const server = http.createServer((req, res) => {
                 if (q.name && String(q.name).trim()) {
                   markdown += `__Question Name__\n\n${String(q.name).trim()}\n\n`;
                 }
+                // List options in authored source order (A, B, C, ...) rather than
+                // shuffled display order, so the persisted question mirrors question.md.
+                const orderedOptions = q.options.slice().sort((a, b) =>
+                  String(a.label || '').localeCompare(String(b.label || ''))
+                );
                 markdown += `__Practice Question__\n\n${q.text}\n\n`;
-                q.options.forEach(opt => {
+                orderedOptions.forEach(opt => {
                   markdown += `${opt.label}. ${opt.text}\n`;
                 });
                 markdown += '\n';
                 markdown += `__Suggested Answers__\n\n`;
-                q.options.forEach(opt => {
+                orderedOptions.forEach(opt => {
                   const correctMarker = opt.correct ? ' - Correct' : '';
                   markdown += `- ${opt.label}${correctMarker}\n`;
                 });


### PR DESCRIPTION
## Summary

Fixes an accessibility bug where NVDA (and other screen readers) announced shuffled MCQ options with the authored letter rather than the visual position — e.g. reading `A → D → C → B` instead of `A → B → C → D`. Reported in [CodeSignal/codesignal#40451](https://github.com/CodeSignal/codesignal/issues/40451) (WCAG 1.3.1, Major).

Root cause: options are shuffled once on the server but each option keeps its authored source letter in `option.label`, which the client rendered into the radio `value` and `aria-label`. After a shuffle, the accessible name no longer matched the visual order.

### Approach

Introduce two label spaces:
- **`label`** (unchanged): the authored source letter (A/B/C/D tied to a specific answer text), used for grading and `report.md` / `score.json` / `answer.md` output.
- **`displayLabel`** (new): A/B/C/D by shuffled display position — what the learner and screen reader perceive.

Changes:
- **`server.js`**: after shuffling, stamp each option with `displayLabel` by final position. Also list `answer.md`'s re-embedded question in authored source order (was shuffled order).
- **`public/modules/mcq.js`**: render radio `value`, `aria-label`, and the visible label from `displayLabel` (with a `displayLabel || label` fallback for older payloads / editor previews). Selection is tracked in display space; two thin translation edges map persisted answers source→display on load and selections display→source when posting results / highlighting.

Because the client still posts source labels and reload still reads them, `report.md`, `score.json`, `answer.md`, `parseAnswersFromMarkdown`, and `lib/activity-results-validation.js` are unchanged — this is exactly "translate for the view, translate back for the report."

## Test plan

- [x] Existing suite passes (`npm test`, 50/50)
- [x] `/api/activity` returns options in `A → B → C → D` display order with source labels preserved
- [x] End-to-end POST round-trip: selecting the option shown as `D` (source `B`, correct) yields `score.json` 1/1 and `report.md`/`answer.md` in authored A→B→C→D space
- [x] Reload: stored source `B` re-checks the correct display slot
- [x] Manual NVDA verification on the affected practice page

Made with [Cursor](https://cursor.com)