### PR TITLE
A11y | Stop announcing the whole activity as a live region

### DIFF
--- a/a11y-audits/8-13-26/resolution-plan.md
+++ b/a11y-audits/8-13-26/resolution-plan.md
@@ -2,7 +2,7 @@
 
 **Audit:** [audit.md](./audit.md) (approved)  
 **Standard:** WCAG 2.2 AA  
-**Status:** Plan only. No issues filed. No product code. Waiting on “go” to execute.
+**Status:** Wave 0 on `main` (PR #20). Wave 1 executing. Product calls P1–P7 use the recommended defaults.
 
 In scope: **A1–A11, D1–D2**. Out of this plan: A12–A20, D3 (Phase 4 after these are on `main`).
 
@@ -243,22 +243,22 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 
 | Audit | Issue | Wave | PR | Status |
 | --- | --- | --- | --- | --- |
-| Wave 0 CI | | 0 | | In this branch |
-| A1 | | 1 | | Open |
-| A4 | | 1 (bundle Sort) | | Open |
-| A5 | | 1 (bundle Sort) | | Open |
-| A6 | | 1 (bundle Sort) | | Open |
-| A3 | | 1 | | Open |
-| A9 | | 1 | | Open |
-| A11 | | 1 | | Open |
-| D2 | (DS repo) | 1 ∥ | | Open |
-| D1 | (DS repo) | 1 ∥ / 3 | | Open |
-| DS bump D2 | | after D2 | | Blocked |
-| DS bump D1 | | after D1 | | Blocked |
-| A2 | | 2 | | Open |
-| A10 | | 2 | | Open |
-| A7 | | 3 | | Open |
-| A8 | | 3 | | Open |
+| Wave 0 CI | #21 | 0 | #20 | Closed (PR #20) |
+| A1 | #22 | 1 | | Open |
+| A4 | #23 | 1 (bundle Sort) | | Open |
+| A5 | #24 | 1 (bundle Sort) | | Open |
+| A6 | #25 | 1 (bundle Sort) | | Open |
+| A3 | #26 | 1 | | Open |
+| A9 | #27 | 1 | | Open |
+| A11 | #28 | 1 | | Open |
+| D2 | [DS #28](https://github.com/CodeSignal/learn_bespoke-design-system/issues/28) | 1 ∥ | | Open |
+| D1 | [DS #29](https://github.com/CodeSignal/learn_bespoke-design-system/issues/29) | 1 ∥ / 3 | | Open |
+| DS bump D2 | #29 | after D2 | | Blocked |
+| DS bump D1 | #30 | after D1 | | Blocked |
+| A2 | #31 | 2 | | Open |
+| A10 | #32 | 2 | | Open |
+| A7 | #33 | 3 | | Open |
+| A8 | #34 | 3 | | Open |
 
 ---
 
@@ -273,4 +273,4 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 
 ## Next step
 
-Confirm product calls **P1–P7** (or say “use the recommendations”). Then say **go** and the next actions are: create labels + milestone, file issues from this map, land Wave 0, then Wave 1.
+P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). Wave 1 starts at A1 (`fix/a11y-live-region`, #22).

--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,7 @@
 <body>
 
   <main class="main">
-    <div id="activity-container" class="activity-container" aria-live="polite"></div>
+    <div id="activity-container" class="activity-container"></div>
   </main>
 
   <noscript>

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -23,7 +23,7 @@ test('A1: #activity-container is not a live region', () => {
   assert.ok(open, 'activity-container exists');
   assert.doesNotMatch(
     open[0],
-    /aria-live/,
+    /(?:^|\s)aria-live(?:\s*=|[\s/>])/i,
     'activity-container must not dump the whole activity to a live region (audit A1)'
   );
 });

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -17,13 +17,14 @@ function sliceFn(src, name) {
   return src.slice(start, end);
 }
 
-test('A1 characterization: #activity-container is a polite live region', () => {
-  // Wave 1 A1 removes aria-live from this node and should flip this assertion.
+test('A1: #activity-container is not a live region', () => {
   const html = read('public/index.html');
-  assert.match(
-    html,
-    /id="activity-container"[^>]*aria-live="polite"/,
-    'activity-container currently dumps the whole activity to a live region (audit A1)'
+  const open = html.match(/<div id="activity-container"[^>]*>/);
+  assert.ok(open, 'activity-container exists');
+  assert.doesNotMatch(
+    open[0],
+    /aria-live/,
+    'activity-container must not dump the whole activity to a live region (audit A1)'
   );
 });
 


### PR DESCRIPTION
## Summary

Removes `aria-live="polite"` from `#activity-container` so loading or swapping an activity does not dump the whole page to a live region (audit A1, WCAG 4.1.3).

Closes #22.

## Changes

`#activity-container` still mounts every activity, but it is no longer a live region. Validate announcements stay for A10 (#32). This PR does not add a status node.

The Wave 0 characterization test now asserts the fixed contract. The resolution-plan issue map is filled with the filed ticket numbers.

Axe was silent on this finding, so the baseline is unchanged.

## Test plan

- [x] `npm test` (A1 characterization asserts no `aria-live` on `#activity-container`)
- [x] Confirm `unit` and `axe` PR checks stay green (axe floor should not change)
- [x] Manual: VoiceOver/NVDA does not hear the full activity on load
