### PR TITLE
A11y | Restore Sort focus and valid chip/category roles

### DIFF
--- a/a11y-audits/8-13-26/resolution-plan.md
+++ b/a11y-audits/8-13-26/resolution-plan.md
@@ -244,7 +244,7 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 | Audit | Issue | Wave | PR | Status |
 | --- | --- | --- | --- | --- |
 | Wave 0 CI | #21 | 0 | #20 | Closed (PR #20) |
-| A1 | #22 | 1 | | Open |
+| A1 | #22 | 1 | #35 | Closed (PR #35) |
 | A4 | #23 | 1 (bundle Sort) | | Open |
 | A5 | #24 | 1 (bundle Sort) | | Open |
 | A6 | #25 | 1 (bundle Sort) | | Open |
@@ -273,4 +273,4 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 
 ## Next step
 
-P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). Wave 1 starts at A1 (`fix/a11y-live-region`, #22).
+P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Wave 1 continues with the Sort bundle (`fix/a11y-sort-widget`, #23 #24 #25).

--- a/a11y-audits/tools/axe-baseline.json
+++ b/a11y-audits/tools/axe-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-13T14:59:07.869Z",
+  "generatedAt": "2026-08-13T19:40:38.426Z",
   "tags": [
     "wcag2a",
     "wcag2aa",
@@ -9,9 +9,7 @@
   ],
   "byRule": {
     "aria-input-field-name": 2,
-    "color-contrast": 25,
-    "aria-allowed-attr": 2,
-    "nested-interactive": 2
+    "color-contrast": 25
   },
   "byState": {
     "fib-unanswered/light": {},
@@ -35,20 +33,16 @@
       "color-contrast": 4
     },
     "sort-chip-selected/light": {
-      "aria-allowed-attr": 1,
       "color-contrast": 2
     },
     "sort-chip-selected/dark": {
-      "aria-allowed-attr": 1,
       "color-contrast": 4
     },
     "sort-chip-placed/light": {
-      "color-contrast": 1,
-      "nested-interactive": 1
+      "color-contrast": 1
     },
     "sort-chip-placed/dark": {
-      "color-contrast": 4,
-      "nested-interactive": 1
+      "color-contrast": 4
     },
     "mcq-unanswered/light": {},
     "mcq-unanswered/dark": {},

--- a/a11y-audits/tools/ci.mjs
+++ b/a11y-audits/tools/ci.mjs
@@ -48,14 +48,15 @@ const CI_SCENARIOS = [
     id: 'sort-chip-placed',
     example: 'sort-into-boxes.md',
     setup: async (page) => {
-      // Prefer a tray chip. Enter on an already-placed chip returns it to the tray
-      // (and a prior CI state may have persisted that placement).
-      const placed = page.locator('.categorization-chip.placed');
-      if ((await placed.count()) === 0) {
-        await page.locator('.categorization-tray .categorization-chip').first().click();
-        await page.locator('.categorization-category-head').first().click();
+      // Always select-then-place so A4 can assert focus survived render().
+      // A prior CI state may have persisted placements into data/.
+      const trayChip = page.locator('.categorization-tray .categorization-chip').first();
+      if ((await trayChip.count()) === 0) {
+        await page.locator('.categorization-chip.placed').first().click();
       }
-      await placed.first().waitFor({ state: 'visible', timeout: 5000 });
+      await page.locator('.categorization-tray .categorization-chip').first().click();
+      await page.locator('.categorization-category-head').first().click();
+      await page.locator('.categorization-chip.placed').first().waitFor({ state: 'visible', timeout: 5000 });
     }
   },
   { id: 'mcq-unanswered', example: 'mcq.md', setup: async () => {} },
@@ -134,6 +135,12 @@ async function main() {
           await selectExample(spec.example);
           await openPlay(page);
           await spec.setup(page);
+          if (spec.id === 'sort-chip-selected' || spec.id === 'sort-chip-placed') {
+            const tag = await page.evaluate(() => document.activeElement?.tagName);
+            if (!tag || tag === 'BODY' || tag === 'HTML') {
+              throw new Error(`${spec.id}: focus landed on ${tag || 'null'} after select/place`);
+            }
+          }
           rec.axe = await runAxe(page);
           console.log(`violations=${rec.axe.violations.length}`);
         } catch (err) {

--- a/a11y-audits/tools/scan.mjs
+++ b/a11y-audits/tools/scan.mjs
@@ -127,7 +127,7 @@ const SCENARIOS = [
   scenario('sort-keyboard-place', 'sort-into-boxes.md', async (page) => {
     await page.locator('.categorization-chip').first().focus();
     await page.keyboard.press('Enter');
-    await page.locator('.categorization-category').first().focus();
+    await page.locator('.categorization-category-head').first().focus();
     await page.keyboard.press('Enter');
     await sleep(200);
   }),

--- a/public/modules/sort.css
+++ b/public/modules/sort.css
@@ -152,13 +152,17 @@
   background: var(--Colors-Learn-Practice-Interactive-Choice-Main-Background-Hover);
 }
 
-.categorization-chip:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 4px var(--Colors-Box-Focus-Shadow);
-}
-
 .categorization-chip.active {
   box-shadow: 0 0 0 2px var(--Colors-Primary-Default);
+}
+
+/* Same two-tone ring as matching.css: the grey box token disappears on the chip fill. */
+.categorization-chip:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow:
+    0 0 0 2px var(--Colors-Base-Neutral-1450),
+    0 0 0 4px var(--Colors-Base-Neutral-00);
 }
 
 .categorization-chip.dragging {
@@ -198,6 +202,13 @@
 
 .categorization-chip.incorrect:hover {
   background: var(--Colors-Alert-Error-Light);
+}
+
+.categorization-chip.incorrect:focus-visible {
+  box-shadow:
+    inset 0 0 0 1.5px var(--Colors-Alert-Error-Default),
+    0 0 0 2px var(--Colors-Base-Neutral-1450),
+    0 0 0 4px var(--Colors-Base-Neutral-00);
 }
 
 .categorization-chip-status {

--- a/public/modules/sort.css
+++ b/public/modules/sort.css
@@ -80,6 +80,17 @@
   padding: var(--UI-Spacing-spacing-mxl, 24px);
   text-align: center;
   color: var(--Colors-Learn-Practice-Interactive-Choice-Main-Label);
+  border: none;
+  background: transparent;
+  width: 100%;
+  font: inherit;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.categorization-category-head:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px var(--Colors-Box-Focus-Shadow);
 }
 
 .categorization-category-head :is(p) {
@@ -200,6 +211,10 @@
   justify-content: center;
   width: 100%;
   padding-bottom: var(--UI-Spacing-spacing-mxl, 24px);
+}
+
+.categorization-tray-item {
+  display: inline-flex;
 }
 
 /* Empty placeholder slot left behind by a placed item */

--- a/public/modules/sort.css
+++ b/public/modules/sort.css
@@ -68,8 +68,10 @@
   transition: box-shadow 0.15s ease;
 }
 
-/* Whole-card drop/click target highlight */
-.categorization-category.drag-over {
+/* Whole-card drop/click target highlight. Keyboard focus on the heading is
+   the same affordance as dragging over the card. */
+.categorization-category.drag-over,
+.categorization-category:has(.categorization-category-head:focus-visible) {
   box-shadow: inset 0 0 0 2px var(--Colors-Primary-Default);
 }
 
@@ -91,11 +93,8 @@
   cursor: pointer;
 }
 
-/* Inset: the card uses overflow:clip, so an outer ring would show only as a
-   grey line along the drop zone. */
 .categorization-category-head:focus-visible {
   outline: none;
-  box-shadow: inset 0 0 0 4px var(--Colors-Box-Focus-Shadow);
 }
 
 .categorization-category-head :is(p) {
@@ -125,7 +124,8 @@
   margin: auto;
 }
 
-.categorization-category.drag-over .categorization-dropzone {
+.categorization-category.drag-over .categorization-dropzone,
+.categorization-category:has(.categorization-category-head:focus-visible) .categorization-dropzone {
   border-color: var(--Colors-Primary-Default);
   background: var(--Colors-Learn-Practice-Interactive-Choice-Main-Background-Empty);
 }

--- a/public/modules/sort.css
+++ b/public/modules/sort.css
@@ -80,17 +80,22 @@
   padding: var(--UI-Spacing-spacing-mxl, 24px);
   text-align: center;
   color: var(--Colors-Learn-Practice-Interactive-Choice-Main-Label);
+  appearance: none;
   border: none;
   background: transparent;
   width: 100%;
+  margin: 0;
+  box-sizing: border-box;
   font: inherit;
   font-family: inherit;
   cursor: pointer;
 }
 
+/* Inset: the card uses overflow:clip, so an outer ring would show only as a
+   grey line along the drop zone. */
 .categorization-category-head:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 4px var(--Colors-Box-Focus-Shadow);
+  box-shadow: inset 0 0 0 4px var(--Colors-Box-Focus-Shadow);
 }
 
 .categorization-category-head :is(p) {

--- a/public/modules/sort.js
+++ b/public/modules/sort.js
@@ -180,12 +180,14 @@ export function initSort({
     categories.forEach((label, categoryIdx) => {
       const card = document.createElement('div');
       card.className = 'categorization-category';
-      card.setAttribute('tabindex', '0');
-      card.setAttribute('role', 'button');
-      card.setAttribute('aria-label', `Place selected item in ${label}`);
+      card.dataset.categoryIndex = String(categoryIdx);
+      card.setAttribute('role', 'group');
+      card.setAttribute('aria-label', label);
 
-      const head = document.createElement('div');
+      const head = document.createElement('button');
+      head.type = 'button';
       head.className = 'categorization-category-head heading-small';
+      head.setAttribute('aria-label', `Place selected item in ${label}`);
       const labelHtml = activity.categoriesHtml && activity.categoriesHtml[categoryIdx];
       if (labelHtml) {
         head.innerHTML = labelHtml;
@@ -197,8 +199,6 @@ export function initSort({
       const zone = document.createElement('div');
       zone.className = 'categorization-dropzone';
       zone.dataset.category = label;
-      zone.setAttribute('role', 'group');
-      zone.setAttribute('aria-label', `${label} category`);
 
       const placedIndexes = items
         .map((_, idx) => idx)
@@ -214,22 +214,10 @@ export function initSort({
 
       // The whole card is a click/drop target, not just the chip area — this
       // gives a much larger surface to hit, especially for click-to-place.
+      // The head button is the keyboard placement control (Enter/Space).
       card.addEventListener('click', (e) => {
         if (e.target.closest('.categorization-chip')) return;
         if (activeItemIndex !== null) {
-          setPlacement(activeItemIndex, label);
-          activeItemIndex = null;
-          render();
-        }
-      });
-      // Keyboard users select a chip, then press Enter or Space on a category
-      // card to place it — mirroring the click handler above. ARIA buttons
-      // should respond to both keys.
-      card.addEventListener('keydown', (e) => {
-        if (e.key !== 'Enter' && e.key !== ' ') return;
-        if (e.target.closest('.categorization-chip')) return;
-        if (activeItemIndex !== null) {
-          e.preventDefault();
           setPlacement(activeItemIndex, label);
           activeItemIndex = null;
           render();
@@ -253,18 +241,49 @@ export function initSort({
         slot.setAttribute('aria-hidden', 'true');
         elTray.appendChild(slot);
       } else {
+        const item = document.createElement('div');
+        item.className = 'categorization-tray-item';
+        item.setAttribute('role', 'listitem');
         const chip = makeChip(idx, { placed: false });
-        chip.setAttribute('role', 'listitem');
-        elTray.appendChild(chip);
+        item.appendChild(chip);
+        elTray.appendChild(item);
       }
     });
     // The tray is also a drop target for returning items.
     elTray.classList.toggle('has-active', activeItemIndex !== null);
   }
 
+  function captureFocus() {
+    const el = document.activeElement;
+    if (!el || !elContainer.contains(el)) return null;
+    if (el.dataset.itemIndex != null && el.dataset.itemIndex !== '') {
+      return { kind: 'item', index: el.dataset.itemIndex };
+    }
+    const card = el.closest('.categorization-category');
+    if (card && card.dataset.categoryIndex != null) {
+      return { kind: 'category', index: card.dataset.categoryIndex };
+    }
+    return null;
+  }
+
+  function restoreFocus(target) {
+    if (!target) return;
+    let next = null;
+    if (target.kind === 'item') {
+      next = elContainer.querySelector(`[data-item-index="${target.index}"]`);
+    } else if (target.kind === 'category') {
+      next = elContainer.querySelector(
+        `.categorization-category[data-category-index="${target.index}"] .categorization-category-head`
+      );
+    }
+    if (next) next.focus();
+  }
+
   function render() {
+    const target = captureFocus();
     renderCategories();
     renderTray();
+    restoreFocus(target);
   }
 
   function setPlacement(itemIndex, category) {

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -34,8 +34,7 @@ test('A1 characterization: learner document has lang and a main landmark', () =>
   assert.match(html, /<main class="main">/);
 });
 
-test('A5 characterization: the same tray chip is a button with role=listitem and aria-pressed', () => {
-  // Wave 1 Sort widget PR must not leave role=listitem on the same node as aria-pressed.
+test('A5: tray chip is a button with aria-pressed; listitem stays on a wrapper', () => {
   const src = read('public/modules/sort.js');
   const makeChip = sliceFn(src, 'makeChip');
   assert.match(makeChip, /document\.createElement\('button'\)/);
@@ -43,20 +42,33 @@ test('A5 characterization: the same tray chip is a button with role=listitem and
     makeChip,
     /if\s*\(\s*!placed\s*&&\s*activeItemIndex\s*===\s*itemIndex\s*\)[\s\S]*setAttribute\(\s*'aria-pressed',\s*'true'\s*\)/
   );
+  assert.doesNotMatch(makeChip, /setAttribute\(\s*'role',\s*'listitem'\s*\)/);
 
   const tray = sliceFn(src, 'renderTray');
-  assert.match(
+  assert.doesNotMatch(
     tray,
-    /const chip = makeChip\(idx,\s*\{\s*placed:\s*false\s*\}\);\s*chip\.setAttribute\(\s*'role',\s*'listitem'\s*\)/
+    /chip\.setAttribute\(\s*'role',\s*'listitem'\s*\)/
   );
+  assert.match(tray, /setAttribute\(\s*'role',\s*'listitem'\s*\)/);
+  assert.match(tray, /item\.appendChild\(chip\)/);
 });
 
-test('A6 characterization: category role=button cards nest placed chip buttons', () => {
+test('A6: category cards are labeled groups, not role=button wrappers around chips', () => {
   const src = read('public/modules/sort.js');
   const cats = sliceFn(src, 'renderCategories');
-  assert.match(cats, /card\.setAttribute\(\s*'role',\s*'button'\s*\)/);
+  assert.doesNotMatch(cats, /card\.setAttribute\(\s*'role',\s*'button'\s*\)/);
+  assert.match(cats, /card\.setAttribute\(\s*'role',\s*'group'\s*\)/);
   assert.match(cats, /zone\.appendChild\(makeChip\(idx,\s*\{\s*placed:\s*true\s*\}\)\)/);
   assert.match(cats, /card\.appendChild\(zone\)/);
+  assert.match(cats, /head = document\.createElement\('button'\)/);
+});
+
+test('A4: render restores focus via data-item-index after rebuild', () => {
+  const src = read('public/modules/sort.js');
+  assert.match(src, /function render\(\) \{\s*const target = captureFocus\(\);/);
+  assert.match(src, /function restoreFocus\(/);
+  assert.match(src, /dataset\.itemIndex/);
+  assert.match(src, /next\.focus\(\)/);
 });
 
 test('A3 characterization: filled blank accessible name stays "blank N"', () => {


### PR DESCRIPTION
## Summary

Sort now keeps keyboard focus across `render()`, and its tray/category markup is valid ARIA (audits A4, A5, A6).

Closes #23, closes #24, closes #25.

## Changes

Tray chips stay `<button aria-pressed>`. `role="listitem"` moves to a wrapper, which clears axe `aria-allowed-attr`.

Category cards are labeled `role="group"` rather than `role="button"` wrapping placed chip buttons. The heading is a real button and is the Enter/Space placement control. Click-to-place on the card (except chips) and drag-and-drop are unchanged.

`render()` captures the focused chip (`data-item-index`) or category head and restores it after the rebuild, so focus does not land on `body`.

Characterization tests lock the new contracts. Playwright CI asserts `document.activeElement` is not `body`/`html` after `sort-chip-selected` and `sort-chip-placed`. The placed setup always select-then-places, even if a prior run persisted a placement.

Axe dropped `aria-allowed-attr` and `nested-interactive`. Floor is `aria-input-field-name` 2 and `color-contrast` 25.

The resolution-plan issue map records A1 as Closed (PR #35).

## Test plan

- [x] `npm test` (A4/A5/A6 characterization flipped)
- [x] `npm run a11y:ci` (floor `aria-input-field-name` 2, `color-contrast` 25; Sort focus check)
- [ ] Keyboard: select a tray chip, Tab to a category heading, Enter to place. Focus should stay on the chip or heading, not jump to the top of the page.
- [ ] Mouse click-to-place (card, not chip) and drag-and-drop still work.
- [ ] Confirm `unit` and `axe` PR checks stay green.
