### PR TITLE
A11y | Name filled FIB blanks with the chosen value

### DIFF
--- a/public/modules/fib.js
+++ b/public/modules/fib.js
@@ -120,6 +120,12 @@ export function initFib({
       const value = selectedByBlankIdx[i];
       blank.textContent = value || '';
       blank.classList.toggle('empty', !value);
+      if (value) {
+        // Visible choice text is the accessible name; drop the placeholder label.
+        blank.removeAttribute('aria-label');
+      } else {
+        blank.setAttribute('aria-label', `blank ${i + 1}`);
+      }
     });
   }
 

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -89,7 +89,7 @@ test('A3: filled blank accessible name is the chosen value', () => {
   );
   assert.match(
     fn,
-    /setAttribute\(\s*['"]aria-label['"],\s*`blank \$\{/,
+    /setAttribute\(\s*['"]aria-label['"],\s*`blank \$\{i \+ 1\}`/,
     'empty blanks restore the placeholder name'
   );
 });

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -71,21 +71,26 @@ test('A4: render restores focus via data-item-index after rebuild', () => {
   assert.match(src, /next\.focus\(\)/);
 });
 
-test('A3 characterization: filled blank accessible name stays "blank N"', () => {
+test('A3: filled blank accessible name is the chosen value', () => {
   const server = read('server.js');
   assert.match(
     server,
     /aria-label="blank \$\{currentIndex \+ 1\}"/,
-    'server stamps aria-label="blank N" on each blank span'
+    'server stamps aria-label="blank N" on each empty blank span'
   );
 
   const src = read('public/modules/fib.js');
   const fn = sliceFn(src, 'updateBlankDisplays');
   assert.match(fn, /blank\.textContent\s*=\s*value/);
-  assert.doesNotMatch(
+  assert.match(
     fn,
-    /aria-label/,
-    'updateBlankDisplays never updates the accessible name when filling a blank'
+    /if\s*\(\s*value\s*\)[\s\S]*removeAttribute\(\s*['"]aria-label['"]\)/,
+    'filled blanks drop aria-label so the visible value is the accessible name'
+  );
+  assert.match(
+    fn,
+    /setAttribute\(\s*['"]aria-label['"],\s*`blank \$\{/,
+    'empty blanks restore the placeholder name'
   );
 });
 


### PR DESCRIPTION
## Summary

Filled FIB blanks now use the chosen value as their accessible name (audit A3, WCAG 4.1.2 / 1.3.1). Empty blanks keep the `blank N` placeholder.

Closes #26.

## Changes

`updateBlankDisplays` drops the server-stamped `aria-label` when a value is present, so the visible text is the name. Empty blanks restore `blank N`. Matching already does this on the selection area.

The Wave 0 characterization test now asserts the fixed contract. Axe did not flag this (`aria-input-field-name` is A2), so the baseline is unchanged.

## Test plan

- [x] `npm test` (A3 characterization asserts filled blanks drop `aria-label` and empty blanks restore it)
- [ ] Confirm `unit` and `axe` PR checks stay green (axe floor should not change)
- [ ] Manual: fill a blank, confirm the name is the value; clear it and confirm `blank N` returns
