### PR TITLE
A11y | Title side-content iframes from content type

### DIFF
--- a/a11y-audits/8-13-26/resolution-plan.md
+++ b/a11y-audits/8-13-26/resolution-plan.md
@@ -248,7 +248,7 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 | A4 | #23 | 1 (bundle Sort) | #36 | Closed (PR #36) |
 | A5 | #24 | 1 (bundle Sort) | #36 | Closed (PR #36) |
 | A6 | #25 | 1 (bundle Sort) | #36 | Closed (PR #36) |
-| A3 | #26 | 1 | | Open |
+| A3 | #26 | 1 | #37 | Closed (PR #37) |
 | A9 | #27 | 1 | | Open |
 | A11 | #28 | 1 | | Open |
 | D2 | [DS #28](https://github.com/CodeSignal/learn_bespoke-design-system/issues/28) | 1 ∥ | | Open |
@@ -273,4 +273,4 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 
 ## Next step
 
-P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). Wave 1 continues with A3 (`fix/a11y-fib-blank-name`, #26).
+P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). A3 is on `main` (PR #37). Wave 1 continues with A9 (`fix/a11y-iframe-title`, #27).

--- a/public/utils/activity-content-shell.js
+++ b/public/utils/activity-content-shell.js
@@ -122,6 +122,8 @@ export function mountActivityContentShell({ container, content }) {
   const iframe = document.createElement('iframe');
   iframe.className = 'activity-content-iframe';
   iframe.setAttribute('frameborder', '1');
+  const sideUrl = hasUrl ? String(content.url || '') : '';
+  iframe.title = sideUrl === '/sim' || sideUrl.startsWith('/sim/') ? 'Simulation' : 'Reference';
   leftPanel.appendChild(iframe);
 
   rightPanel.className = 'activity-main-pane';

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -94,8 +94,7 @@ test('A3: filled blank accessible name is the chosen value', () => {
   );
 });
 
-test('A9 characterization: side-content iframe is created and sourced without a title', () => {
-  // Wave 1 A9 should set title (or aria-label) on the iframe.
+test('A9: side-content iframe has a title from content type', () => {
   const src = read('public/utils/activity-content-shell.js');
   const start = src.indexOf("document.createElement('iframe')");
   const end = src.indexOf('const cleanup', start);
@@ -105,9 +104,16 @@ test('A9 characterization: side-content iframe is created and sourced without a 
   assert.match(block, /activity-content-iframe/);
   assert.match(block, /leftPanel\.appendChild\(iframe\)/);
   assert.match(block, /iframe\.src\s*=/);
-  assert.doesNotMatch(block, /\.title\s*=/);
-  assert.doesNotMatch(block, /setAttribute\(\s*['"]title['"]/);
-  assert.doesNotMatch(block, /setAttribute\(\s*['"]aria-label['"]/);
+  assert.match(
+    block,
+    /iframe\.title\s*=[\s\S]*\? ['"]Simulation['"] : ['"]Reference['"]/,
+    'markdown and external URLs are Reference; /sim/ is Simulation'
+  );
+  assert.match(
+    block,
+    /startsWith\(\s*['"]\/sim\//,
+    '/sim/ content is titled Simulation'
+  );
 });
 
 test('A11 characterization: Matching choices are buttons with role=option in a listbox', () => {


### PR DESCRIPTION
## Summary

Side-content iframes now have a `title` so screen-reader and keyboard users can tell the frame from the splitter (audit A9, WCAG 4.1.2 / 2.4.1).

Closes #27.

## Changes

P4 strings: markdown and external URLs are `Reference`; `/sim/` is `Simulation`. The title is set when the iframe is created, before `src`.

The Wave 0 characterization test now asserts that contract. Axe excludes these iframes, so the baseline is unchanged.

Also records A3 as closed (PR #37) on the issue map.

## Test plan

- [x] `npm test` (A9 characterization asserts P4 titles)
- [x] Confirm `unit` and `axe` PR checks stay green (axe floor should not change)
- [x] Manual: split markdown, `/sim/`, and an external URL each show the matching iframe title
