### PR TITLE
A11y | Treat Matching choices as a labeled group of buttons

### DIFF
--- a/a11y-audits/8-13-26/resolution-plan.md
+++ b/a11y-audits/8-13-26/resolution-plan.md
@@ -249,7 +249,7 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 | A5 | #24 | 1 (bundle Sort) | #36 | Closed (PR #36) |
 | A6 | #25 | 1 (bundle Sort) | #36 | Closed (PR #36) |
 | A3 | #26 | 1 | #37 | Closed (PR #37) |
-| A9 | #27 | 1 | | Open |
+| A9 | #27 | 1 | #38 | Closed (PR #38) |
 | A11 | #28 | 1 | | Open |
 | D2 | [DS #28](https://github.com/CodeSignal/learn_bespoke-design-system/issues/28) | 1 ∥ | | Open |
 | D1 | [DS #29](https://github.com/CodeSignal/learn_bespoke-design-system/issues/29) | 1 ∥ / 3 | | Open |
@@ -273,4 +273,4 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 
 ## Next step
 
-P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). A3 is on `main` (PR #37). Wave 1 continues with A9 (`fix/a11y-iframe-title`, #27).
+P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). A3 is on `main` (PR #37). A9 is on `main` (PR #38). Wave 1 continues with A11 (`fix/a11y-matching-listbox`, #28).

--- a/public/modules/matching.js
+++ b/public/modules/matching.js
@@ -22,7 +22,7 @@ export function initMatching({
   elContainer.innerHTML = `
     <div id="matching" class="matching">
       <div id="matching-cards-container" class="matching-cards-container"></div>
-      <div id="matching-choices" class="matching-choices" role="listbox" aria-label="Answer choices"></div>
+      <div id="matching-choices" class="matching-choices" role="group" aria-label="Answer choices"></div>
     </div>
   `;
   
@@ -212,7 +212,6 @@ export function initMatching({
       const choiceButton = document.createElement('button');
       choiceButton.className = 'matching-choice-button button button-primary body-large';
       choiceButton.textContent = choice;
-      choiceButton.setAttribute('role', 'option');
       choiceButton.setAttribute('aria-label', `Select ${choice}`);
       
       // Check if this choice is available

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -116,10 +116,12 @@ test('A9: side-content iframe has a title from content type', () => {
   );
 });
 
-test('A11 characterization: Matching choices are buttons with role=option in a listbox', () => {
-  // Wave 1 A11 drops listbox/option on native buttons.
+test('A11: Matching choices are a labeled group of buttons', () => {
   const src = read('public/modules/matching.js');
-  assert.match(src, /role="listbox"/);
+  assert.doesNotMatch(src, /role="listbox"/);
+  assert.doesNotMatch(src, /setAttribute\(\s*'role',\s*'option'\s*\)/);
+  assert.match(src, /id="matching-choices"[^>]*role="group"/);
+  assert.match(src, /aria-label="Answer choices"/);
   assert.match(src, /createElement\('button'\)/);
-  assert.match(src, /setAttribute\(\s*'role',\s*'option'\s*\)/);
+  assert.match(src, /choiceButton\.disabled\s*=\s*true/);
 });


### PR DESCRIPTION
## Summary

Matching answer choices are native buttons in a labeled group, not `role="option"` nodes inside a `role="listbox"` (audit A11, WCAG 4.1.2). Used choices stay disabled.

Closes #28.

## Changes

`#matching-choices` is `role="group"` with the existing `Answer choices` name. Choice nodes stay `<button>` and keep their click handler and `disabled` used state. That matches how they already work from the keyboard (Tab and Enter/Space), without implying listbox arrow / `aria-activedescendant` behavior.

The Wave 0 characterization test now asserts that contract. Axe did not flag the mixed roles, so the baseline is unchanged.

Also records A9 as closed (PR #38) on the issue map.

## Test plan

- [x] `npm test` (A11 characterization asserts group + buttons, no listbox/option, used choices still disabled)
- [x] Confirm `unit` and `axe` PR checks stay green (axe floor should not change)
- [x] Manual: Tab to a choice and activate it; used choices stay disabled
