### PR TITLE
A11y | Make the FIB listbox a named keyboard widget

### DIFF
--- a/a11y-audits/8-13-26/resolution-plan.md
+++ b/a11y-audits/8-13-26/resolution-plan.md
@@ -250,7 +250,7 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 | A6 | #25 | 1 (bundle Sort) | #36 | Closed (PR #36) |
 | A3 | #26 | 1 | #37 | Closed (PR #37) |
 | A9 | #27 | 1 | #38 | Closed (PR #38) |
-| A11 | #28 | 1 | | Open |
+| A11 | #28 | 1 | #39 | Closed (PR #39) |
 | D2 | [DS #28](https://github.com/CodeSignal/learn_bespoke-design-system/issues/28) | 1 ∥ | | Open |
 | D1 | [DS #29](https://github.com/CodeSignal/learn_bespoke-design-system/issues/29) | 1 ∥ / 3 | | Open |
 | DS bump D2 | #29 | after D2 | | Blocked |
@@ -273,4 +273,4 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 
 ## Next step
 
-P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). A3 is on `main` (PR #37). A9 is on `main` (PR #38). Wave 1 continues with A11 (`fix/a11y-matching-listbox`, #28).
+P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). A3 is on `main` (PR #37). A9 is on `main` (PR #38). A11 is on `main` (PR #39). Wave 2 starts with A2 (`fix/a11y-fib-listbox`, #31), then A10 (#32).

--- a/a11y-audits/tools/axe-baseline.json
+++ b/a11y-audits/tools/axe-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-13T19:40:38.426Z",
+  "generatedAt": "2026-08-19T20:48:34.865Z",
   "tags": [
     "wcag2a",
     "wcag2aa",
@@ -8,18 +8,13 @@
     "wcag22aa"
   ],
   "byRule": {
-    "aria-input-field-name": 2,
     "color-contrast": 25
   },
   "byState": {
     "fib-unanswered/light": {},
     "fib-unanswered/dark": {},
-    "fib-dropdown-open/light": {
-      "aria-input-field-name": 1
-    },
-    "fib-dropdown-open/dark": {
-      "aria-input-field-name": 1
-    },
+    "fib-dropdown-open/light": {},
+    "fib-dropdown-open/dark": {},
     "matching-empty/light": {
       "color-contrast": 2
     },

--- a/public/modules/fib.css
+++ b/public/modules/fib.css
@@ -228,6 +228,11 @@
   font-weight: 500;
 }
 
+.fib-option:focus {
+  outline: 2px solid var(--Colors-Primary-Medium);
+  outline-offset: -2px;
+}
+
 .fib-option-hover-measure {
   font-weight: 500;
 }

--- a/public/modules/fib.js
+++ b/public/modules/fib.js
@@ -81,6 +81,7 @@ export function initFib({
   // Prepare blanks to be clickable triggers
   blanks.forEach((blank) => {
     const idx = parseInt(blank.getAttribute('data-blank') || '0', 10);
+    if (!blank.id) blank.id = `fib-blank-${idx}`;
     blank.setAttribute('role', 'button');
     blank.setAttribute('aria-haspopup', 'listbox');
     blank.setAttribute('aria-expanded', 'false');
@@ -94,6 +95,10 @@ export function initFib({
       openMenuForBlank(blank, idx);
     });
     blank.addEventListener('keydown', (e) => {
+      if (openDropdown && openDropdown.blank === blank) {
+        handleMenuKeydown(e);
+        return;
+      }
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         if (selectedByBlankIdx[idx]) {
@@ -140,11 +145,46 @@ export function initFib({
     const { container, blank } = openDropdown;
     if (container && container.parentNode) container.parentNode.removeChild(container);
     blank.setAttribute('aria-expanded', 'false');
+    blank.removeAttribute('aria-controls');
     blank.classList.remove('dropdown-open');
     document.removeEventListener('mousedown', handleOutside);
     window.removeEventListener('resize', closeMenu);
     window.removeEventListener('scroll', handleOutsideScroll, true);
     openDropdown = null;
+  }
+
+  function dismissMenu() {
+    const blank = openDropdown?.blank;
+    closeMenu();
+    if (blank && blank.isConnected) blank.focus();
+  }
+
+  function handleMenuKeydown(e) {
+    if (!openDropdown) return;
+    const items = Array.from(openDropdown.container.querySelectorAll('.fib-option'));
+    const currentIndex = items.findIndex((item) => item === document.activeElement);
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (items.length === 0) return;
+      const nextIndex = currentIndex < items.length - 1 ? currentIndex + 1 : 0;
+      items[nextIndex].focus();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (items.length === 0) return;
+      const prevIndex = currentIndex > 0 ? currentIndex - 1 : items.length - 1;
+      items[prevIndex].focus();
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      if (currentIndex < 0) return;
+      const blank = openDropdown.blank;
+      setSelection(openDropdown.idx, items[currentIndex].textContent);
+      closeMenu();
+      if (blank.isConnected) blank.focus();
+    } else if (e.key === 'Escape' || e.key === 'Tab') {
+      e.preventDefault();
+      dismissMenu();
+    }
   }
 
   function handleOutside(e) {
@@ -191,8 +231,10 @@ export function initFib({
     });
     
     const menu = document.createElement('div');
+    menu.id = 'fib-listbox';
     menu.className = 'fib-dropdown';
     menu.setAttribute('role', 'listbox');
+    menu.setAttribute('aria-labelledby', blank.id);
     menu.style.position = 'absolute';
     menu.style.minWidth = Math.max(rect.width, 220) + 'px';
 
@@ -208,6 +250,7 @@ export function initFib({
       const opt = document.createElement('div');
       opt.className = 'fib-option';
       opt.setAttribute('role', 'option');
+      opt.tabIndex = -1;
       opt.textContent = choice;
       
       if (choice === current) {
@@ -218,6 +261,7 @@ export function initFib({
         e.preventDefault();
         setSelection(idx, choice);
         closeMenu();
+        if (blank.isConnected) blank.focus();
       });
       menu.appendChild(opt);
     });
@@ -242,7 +286,13 @@ export function initFib({
     }
 
     blank.setAttribute('aria-expanded', 'true');
+    blank.setAttribute('aria-controls', menu.id);
     openDropdown = { container: menu, blank, idx };
+
+    menu.addEventListener('keydown', handleMenuKeydown);
+    const options = menu.querySelectorAll('.fib-option');
+    const initial = menu.querySelector('.fib-option.selected') || options[0];
+    if (initial) initial.focus();
     
     // Add mouse event listeners to maintain hover state
     menu.addEventListener('mouseenter', handleDropdownMouseEnter);

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -71,6 +71,27 @@ test('A4: render restores focus via data-item-index after rebuild', () => {
   assert.match(src, /next\.focus\(\)/);
 });
 
+test('A2: FIB listbox is named and keyboard-operable', () => {
+  const src = read('public/modules/fib.js');
+  const open = sliceFn(src, 'openMenuForBlank');
+  const close = sliceFn(src, 'closeMenu');
+  const keys = sliceFn(src, 'handleMenuKeydown');
+
+  assert.match(open, /setAttribute\(\s*['"]role['"],\s*['"]listbox['"]\)/);
+  assert.match(open, /setAttribute\(\s*['"]aria-labelledby['"]/);
+  assert.match(open, /setAttribute\(\s*['"]aria-controls['"]/);
+  assert.match(open, /createElement\('div'\)/);
+  assert.doesNotMatch(open, /createElement\('button'\)/);
+  assert.match(open, /setAttribute\(\s*['"]role['"],\s*['"]option['"]\)/);
+  assert.match(close, /removeAttribute\(\s*['"]aria-controls['"]\)/);
+
+  assert.match(keys, /ArrowDown/);
+  assert.match(keys, /ArrowUp/);
+  assert.match(keys, /['"]Enter['"]/);
+  assert.match(keys, /Escape/);
+  assert.match(keys, /Tab/);
+});
+
 test('A3: filled blank accessible name is the chosen value', () => {
   const server = read('server.js');
   assert.match(


### PR DESCRIPTION
## Summary

The FIB choice menu is a named listbox that keyboard users can open, move through, commit, and dismiss (audit A2, WCAG 2.1.1 / 4.1.2 / 1.4.13).

Closes #31.

## Changes

Keep the inline blank and `.fib-dropdown` / `.fib-option` markup. The listbox is named with `aria-labelledby` on the triggering blank (no new copy), and the blank gets `aria-controls` while the menu is open.

Keyboard matches DS dropdown: arrows wrap, Enter/Space commit, Escape closes and returns focus to the blank. Tab and Shift+Tab also close, because the menu lives on `document.body` and would otherwise stay open after focus leaves. Options stay non-button `role="option"` nodes (P2).

Axe `aria-input-field-name` is gone. Floor is `color-contrast` 25. Characterization locks the named listbox, `aria-controls`, and Arrow / Enter / Escape / Tab handlers. A3 empty/filled blank names are unchanged.

Also records A11 as closed (PR #39) on the issue map.

## Test plan

- [x] `npm test` (A2 characterization; A3 still requires `blank ${i + 1}`)
- [x] `npm run a11y:ci` then `WRITE_BASELINE=1 npm run a11y:ci` (`aria-input-field-name` cleared; `color-contrast` still 25)
- [x] Manual: Tab to an empty blank, Enter, arrows, Enter commits, Escape dismisses, Tab does not leave a stray menu
