### PR TITLE
A11y | Announce validate errors as status and invalid

### DIFF
--- a/a11y-audits/8-13-26/resolution-plan.md
+++ b/a11y-audits/8-13-26/resolution-plan.md
@@ -255,7 +255,7 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 | D1 | [DS #29](https://github.com/CodeSignal/learn_bespoke-design-system/issues/29) | 1 ∥ / 3 | | Open |
 | DS bump D2 | #29 | after D2 | | Blocked |
 | DS bump D1 | #30 | after D1 | | Blocked |
-| A2 | #31 | 2 | | Open |
+| A2 | #31 | 2 | #40 | Closed (PR #40) |
 | A10 | #32 | 2 | | Open |
 | A7 | #33 | 3 | | Open |
 | A8 | #34 | 3 | | Open |
@@ -273,4 +273,4 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 
 ## Next step
 
-P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). A3 is on `main` (PR #37). A9 is on `main` (PR #38). A11 is on `main` (PR #39). Wave 2 starts with A2 (`fix/a11y-fib-listbox`, #31), then A10 (#32).
+P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). A3 is on `main` (PR #37). A9 is on `main` (PR #38). A11 is on `main` (PR #39). A2 is on `main` (PR #40). Wave 2 continues with A10 (`fix/a11y-validate-status`, #32).

--- a/public/app.js
+++ b/public/app.js
@@ -7,6 +7,7 @@ import { initTextInput } from './modules/text-input.js';
 import { initMatrix } from './modules/matrix.js';
 import toolbar from './components/toolbar.js';
 import { mountActivityContentShell } from './utils/activity-content-shell.js';
+import { setValidateStatus } from './utils/validate-status.js';
 
 (() => {
   'use strict';
@@ -63,6 +64,7 @@ import { mountActivityContentShell } from './utils/activity-content-shell.js';
       contentShellCleanup = null;
     }
     toolbar.clear();
+    setValidateStatus(false);
   }
 
   async function loadActivityJson() {

--- a/public/index.html
+++ b/public/index.html
@@ -34,6 +34,7 @@
 <body>
 
   <main class="main">
+    <div id="activity-status" class="activity-status" role="status"></div>
     <div id="activity-container" class="activity-container"></div>
   </main>
 

--- a/public/modules/matrix.js
+++ b/public/modules/matrix.js
@@ -1,6 +1,13 @@
 import toolbar from '../components/toolbar.js';
 import { detectQuoteBlockquotes } from '../design-system/typography/typography.js';
 import { renderMath } from '../utils/katex-render.js';
+import {
+  clearControlInvalid,
+  ensureErrorText,
+  removeErrorText,
+  setControlInvalid,
+  setValidateStatus
+} from '../utils/validate-status.js';
 
 export function initMatrix({
   activity,
@@ -201,22 +208,39 @@ export function initMatrix({
 
   detectQuoteBlockquotes(elContainer.querySelector('#matrix-root'));
 
+  function markRowIncorrect(tr, idx, incorrect) {
+    const errorId = `matrix-error-${idx}`;
+    const radios = tr.querySelectorAll('input[type="radio"]');
+    tr.classList.toggle('matrix-row-incorrect', incorrect);
+    if (incorrect) {
+      ensureErrorText(tr.querySelector('.matrix-row-label') || tr, errorId);
+      radios.forEach((input) => setControlInvalid(input, errorId));
+    } else {
+      removeErrorText(errorId);
+      radios.forEach(clearControlInvalid);
+    }
+  }
+
   function clearValidation() {
     if (!isValidating) return;
     isValidating = false;
-    elTbody.querySelectorAll('tr').forEach(tr => {
-      tr.classList.remove('matrix-row-incorrect');
+    elTbody.querySelectorAll('tr').forEach((tr, idx) => {
+      markRowIncorrect(tr, idx, false);
     });
+    setValidateStatus(false);
   }
 
   function validateAnswers() {
     isValidating = true;
+    let hasIncorrect = false;
     elTbody.querySelectorAll('tr').forEach((tr, idx) => {
       const sel = selectedColIndexByRow[idx];
       const correctIdx = correctColumnIndexByRow[idx];
       const ok = sel !== null && sel !== undefined && sel === correctIdx;
-      tr.classList.toggle('matrix-row-incorrect', !ok);
+      if (!ok) hasIncorrect = true;
+      markRowIncorrect(tr, idx, !ok);
     });
+    setValidateStatus(hasIncorrect);
   }
 
   function updateResultsAndPost() {

--- a/public/modules/mcq.js
+++ b/public/modules/mcq.js
@@ -1,6 +1,13 @@
 import toolbar from '../components/toolbar.js';
 import { detectQuoteBlockquotes } from '../design-system/typography/typography.js';
 import { renderMath } from '../utils/katex-render.js';
+import {
+  clearControlInvalid,
+  ensureErrorText,
+  removeErrorText,
+  setControlInvalid,
+  setValidateStatus
+} from '../utils/validate-status.js';
 
 export function initMcq({
   activity,
@@ -375,6 +382,7 @@ export function initMcq({
     
     const errorIcon = document.createElement('div');
     errorIcon.className = 'mcq-question-error-icon';
+    errorIcon.setAttribute('aria-hidden', 'true');
     errorIcon.innerHTML = `
       <svg viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
         <rect x="5" y="2" width="2" height="5" rx="1" fill="white"/>
@@ -391,6 +399,26 @@ export function initMcq({
     }
   }
   
+  function questionInputs(questionEl) {
+    return questionEl.querySelectorAll('input[type="checkbox"], input[type="radio"]');
+  }
+
+  function markQuestionIncorrect(questionEl, incorrect) {
+    const errorId = `mcq-error-${questionEl.getAttribute('data-question-id')}`;
+    const inputs = questionInputs(questionEl);
+    if (incorrect) {
+      questionEl.classList.add('mcq-question-incorrect');
+      addErrorIcon(questionEl);
+      ensureErrorText(questionEl, errorId);
+      inputs.forEach((input) => setControlInvalid(input, errorId));
+    } else {
+      questionEl.classList.remove('mcq-question-incorrect');
+      removeErrorIcon(questionEl);
+      removeErrorText(errorId);
+      inputs.forEach(clearControlInvalid);
+    }
+  }
+
   function clearValidation() {
     if (!isValidating) return;
     
@@ -398,15 +426,14 @@ export function initMcq({
     // Remove validation classes from all questions
     mcq.questions.forEach(q => {
       const questionEl = elQuestions.querySelector(`[data-question-id="${q.id}"]`);
-      if (questionEl) {
-        questionEl.classList.remove('mcq-question-incorrect');
-        removeErrorIcon(questionEl);
-      }
+      if (questionEl) markQuestionIncorrect(questionEl, false);
     });
+    setValidateStatus(false);
   }
   
   function validateAnswers() {
     isValidating = true;
+    let hasIncorrect = false;
     
     // Check each question and mark incorrect ones
     mcq.questions.forEach(q => {
@@ -427,16 +454,10 @@ export function initMcq({
       }
       
       const questionEl = elQuestions.querySelector(`[data-question-id="${q.id}"]`);
-      if (questionEl) {
-        if (!isCorrect) {
-          questionEl.classList.add('mcq-question-incorrect');
-          addErrorIcon(questionEl);
-        } else {
-          questionEl.classList.remove('mcq-question-incorrect');
-          removeErrorIcon(questionEl);
-        }
-      }
+      if (questionEl) markQuestionIncorrect(questionEl, !isCorrect);
+      if (!isCorrect) hasIncorrect = true;
     });
+    setValidateStatus(hasIncorrect);
   }
   
   function updateResultsAndPost() {

--- a/public/modules/sort.js
+++ b/public/modules/sort.js
@@ -1,5 +1,10 @@
 import { renderMath } from '../utils/katex-render.js';
 import toolbar from '../components/toolbar.js';
+import {
+  INCORRECT_ANSWER_TEXT,
+  setControlInvalid,
+  setValidateStatus
+} from '../utils/validate-status.js';
 
 /**
  * Categorization Sorting activity.
@@ -48,6 +53,7 @@ export function initSort({
         <span class="categorization-instructions-icon" aria-hidden="true">${instructionIconSvg()}</span>
         <p class="categorization-instructions-text body-xxsmall">Click or drag the items onto the cards above</p>
       </div>
+      <p id="sort-validate-error" class="activity-error-text body-small" hidden></p>
       <div class="categorization-tray" id="categorization-tray" role="list" aria-label="Items to sort"></div>
     </div>
   `;
@@ -97,7 +103,7 @@ export function initSort({
     chip.className = `categorization-chip body-large${placed ? ' placed' : ''}${misplaced ? ' incorrect' : ''}`;
     chip.dataset.itemIndex = String(itemIndex);
     chip.setAttribute('draggable', 'true');
-    if (misplaced) chip.setAttribute('aria-invalid', 'true');
+    if (misplaced) setControlInvalid(chip, 'sort-validate-error');
     chip.innerHTML = `${placed ? '' : dragHandleSvg()}<span class="categorization-chip-label">${chipInnerHtml(item)}</span>${misplaced ? incorrectIconSvg() : ''}`;
     chip.setAttribute(
       'aria-label',
@@ -279,10 +285,27 @@ export function initSort({
     if (next) next.focus();
   }
 
+  function anyMisplaced() {
+    return items.some((item, idx) => {
+      return Boolean(placement[idx]) && placement[idx] !== (item.correct || '');
+    });
+  }
+
+  function syncValidateError() {
+    const err = elContainer.querySelector('#sort-validate-error');
+    const show = validating && anyMisplaced();
+    if (err) {
+      err.hidden = !show;
+      err.textContent = show ? INCORRECT_ANSWER_TEXT : '';
+    }
+    setValidateStatus(show);
+  }
+
   function render() {
     const target = captureFocus();
     renderCategories();
     renderTray();
+    syncValidateError();
     restoreFocus(target);
   }
 

--- a/public/modules/text-input.js
+++ b/public/modules/text-input.js
@@ -1,5 +1,12 @@
 import toolbar from '../components/toolbar.js';
 import { renderMath } from '../utils/katex-render.js';
+import {
+  clearControlInvalid,
+  ensureErrorText,
+  removeErrorText,
+  setControlInvalid,
+  setValidateStatus
+} from '../utils/validate-status.js';
 
 export function initTextInput({
   activity,
@@ -593,6 +600,7 @@ export function initTextInput({
     
     const errorIcon = document.createElement('div');
     errorIcon.className = 'text-input-question-error-icon';
+    errorIcon.setAttribute('aria-hidden', 'true');
     errorIcon.innerHTML = `
       <svg viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
         <rect x="5" y="2" width="2" height="5" rx="1" fill="white"/>
@@ -609,6 +617,22 @@ export function initTextInput({
     }
   }
   
+  function markQuestionIncorrect(questionEl, questionId, incorrect) {
+    const errorId = `text-input-error-${questionId}`;
+    const input = document.getElementById(`q${questionId}-input`);
+    if (incorrect) {
+      questionEl.classList.add('text-input-question-incorrect');
+      addErrorIcon(questionEl);
+      ensureErrorText(questionEl, errorId);
+      if (input) setControlInvalid(input, errorId);
+    } else {
+      questionEl.classList.remove('text-input-question-incorrect');
+      removeErrorIcon(questionEl);
+      removeErrorText(errorId);
+      if (input) clearControlInvalid(input);
+    }
+  }
+
   function clearValidation() {
     if (!isValidating) return;
     
@@ -616,32 +640,25 @@ export function initTextInput({
     // Remove validation classes from all questions
     textInput.questions.forEach(q => {
       const questionEl = elQuestions.querySelector(`[data-question-id="${q.id}"]`);
-      if (questionEl) {
-        questionEl.classList.remove('text-input-question-incorrect');
-        removeErrorIcon(questionEl);
-      }
+      if (questionEl) markQuestionIncorrect(questionEl, q.id, false);
     });
+    setValidateStatus(false);
   }
   
   function validateAnswers() {
     isValidating = true;
+    let hasIncorrect = false;
     
     // Check each question and mark incorrect ones
     textInput.questions.forEach(q => {
       const questionEl = elQuestions.querySelector(`[data-question-id="${q.id}"]`);
       
       const isCorrect = validateAnswer(q);
+      if (isCorrect === false) hasIncorrect = true;
       
-      if (questionEl) {
-        if (isCorrect === false) {
-          questionEl.classList.add('text-input-question-incorrect');
-          addErrorIcon(questionEl);
-        } else {
-          questionEl.classList.remove('text-input-question-incorrect');
-          removeErrorIcon(questionEl);
-        }
-      }
+      if (questionEl) markQuestionIncorrect(questionEl, q.id, isCorrect === false);
     });
+    setValidateStatus(hasIncorrect);
   }
   
   function updateResultsAndPost() {

--- a/public/styles.css
+++ b/public/styles.css
@@ -70,6 +70,24 @@ body:has(.matching) {
   position: relative;
 }
 
+/* Visually hidden validate status (4.1.3); keep out of the flex layout. */
+.activity-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.activity-error-text {
+  margin-top: var(--UI-Spacing-spacing-xs, 8px);
+  color: var(--Colors-Text-Body-Default);
+}
+
 /* Activity container */
 .activity-container {
   display: grid;

--- a/public/utils/validate-status.js
+++ b/public/utils/validate-status.js
@@ -1,0 +1,35 @@
+export const INCORRECT_ANSWER_TEXT = 'This answer is incorrect.';
+
+export function setValidateStatus(hasIncorrect) {
+  const el = document.getElementById('activity-status');
+  if (!el) return;
+  el.textContent = '';
+  if (hasIncorrect) el.textContent = INCORRECT_ANSWER_TEXT;
+}
+
+export function setControlInvalid(el, errorId) {
+  el.setAttribute('aria-invalid', 'true');
+  if (errorId) el.setAttribute('aria-describedby', errorId);
+}
+
+export function clearControlInvalid(el) {
+  el.removeAttribute('aria-invalid');
+  el.removeAttribute('aria-describedby');
+}
+
+export function ensureErrorText(parent, id) {
+  let el = document.getElementById(id);
+  if (!el) {
+    el = document.createElement('p');
+    el.id = id;
+    el.className = 'activity-error-text body-small';
+    el.textContent = INCORRECT_ANSWER_TEXT;
+    parent.appendChild(el);
+  }
+  return el;
+}
+
+export function removeErrorText(id) {
+  const el = document.getElementById(id);
+  if (el) el.remove();
+}

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -92,6 +92,35 @@ test('A2: FIB listbox is named and keyboard-operable', () => {
   assert.match(keys, /Tab/);
 });
 
+test('A10: validate errors are named, invalid, and announced', () => {
+  const html = read('public/index.html');
+  assert.match(html, /id="activity-status"[^>]*role="status"/);
+  assert.doesNotMatch(
+    html,
+    /id="activity-container"[^>]*aria-live/i,
+    'status lives on #activity-status, not #activity-container'
+  );
+
+  const util = read('public/utils/validate-status.js');
+  assert.match(util, /This answer is incorrect\./);
+  assert.match(util, /function setValidateStatus/);
+  assert.match(util, /setAttribute\(\s*['"]aria-invalid['"],\s*['"]true['"]\)/);
+
+  for (const file of ['mcq.js', 'text-input.js', 'matrix.js', 'sort.js']) {
+    const src = read(`public/modules/${file}`);
+    assert.match(src, /setValidateStatus/, `${file} updates the status region`);
+  }
+
+  const mcqIcon = sliceFn(read('public/modules/mcq.js'), 'addErrorIcon');
+  assert.match(mcqIcon, /aria-hidden/);
+  const textIcon = sliceFn(read('public/modules/text-input.js'), 'addErrorIcon');
+  assert.match(textIcon, /aria-hidden/);
+
+  const sortChip = sliceFn(read('public/modules/sort.js'), 'makeChip');
+  assert.match(sortChip, /setControlInvalid\(chip,\s*['"]sort-validate-error['"]\)/);
+  assert.match(read('public/modules/sort.js'), /INCORRECT_ANSWER_TEXT/);
+});
+
 test('A3: filled blank accessible name is the chosen value', () => {
   const server = read('server.js');
   assert.match(


### PR DESCRIPTION
## Summary

Incorrect validate now has visible “This answer is incorrect.”, `aria-invalid` on the control, and a short `role="status"` update (audit A10, WCAG 3.3.1 / 4.1.3). Decorative error icons are `aria-hidden`.

Closes #32.

## Changes

MCQ, Text Input, and Matrix keep their existing incorrect chrome. Each incorrect question or row also gets the P5 sentence, `aria-invalid` plus `aria-describedby` on the radios/checkboxes/input, and the decorative icon (where one exists) is hidden from AT.

Sort already marked misplaced chips `aria-invalid`. This PR adds the same visible sentence and points those chips at it. Unplaced tray chips stay unflagged.

`#activity-status` is a sibling of `#activity-container`, so A1's quiet activity root is unchanged. The status node is visually hidden and repeats the short string when any answer is incorrect.

Also records A2 as closed (PR #40) on the issue map.

## Test plan

- [x] `npm test` (A10 characterization; A1 still forbids `aria-live` on `#activity-container`)
- [x] `npm run a11y:ci` (floor unchanged: `color-contrast` 25)
- [ ] Manual: POST `/validate` on MCQ, Text Input, Matrix, and Sort; confirm visible text, `aria-invalid`, icon not announced, and a short status (not the whole page)
