### PR TITLE
A11y | Raise dark Matching and Sort choice contrast

### DIFF
--- a/a11y-audits/8-13-26/resolution-plan.md
+++ b/a11y-audits/8-13-26/resolution-plan.md
@@ -256,7 +256,7 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 | DS bump D2 | #29 | after D2 | | Blocked |
 | DS bump D1 | #30 | after D1 | | Blocked |
 | A2 | #31 | 2 | #40 | Closed (PR #40) |
-| A10 | #32 | 2 | | Open |
+| A10 | #32 | 2 | #41 | Closed (PR #41) |
 | A7 | #33 | 3 | | Open |
 | A8 | #34 | 3 | | Open |
 
@@ -273,4 +273,4 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 
 ## Next step
 
-P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). A3 is on `main` (PR #37). A9 is on `main` (PR #38). A11 is on `main` (PR #39). A2 is on `main` (PR #40). Wave 2 continues with A10 (`fix/a11y-validate-status`, #32).
+P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). A3 is on `main` (PR #37). A9 is on `main` (PR #38). A11 is on `main` (PR #39). A2 is on `main` (PR #40). A10 is on `main` (PR #41). Wave 3 starts with A7 (`fix/a11y-choice-contrast`, #33), then A8 (#34).

--- a/a11y-audits/tools/axe-baseline.json
+++ b/a11y-audits/tools/axe-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-19T20:48:34.865Z",
+  "generatedAt": "2026-08-20T10:48:13.981Z",
   "tags": [
     "wcag2a",
     "wcag2aa",
@@ -8,7 +8,7 @@
     "wcag22aa"
   ],
   "byRule": {
-    "color-contrast": 25
+    "color-contrast": 8
   },
   "byState": {
     "fib-unanswered/light": {},
@@ -19,26 +19,20 @@
       "color-contrast": 2
     },
     "matching-empty/dark": {
-      "color-contrast": 7
+      "color-contrast": 2
     },
     "sort-tray/light": {
       "color-contrast": 1
     },
-    "sort-tray/dark": {
-      "color-contrast": 4
-    },
+    "sort-tray/dark": {},
     "sort-chip-selected/light": {
       "color-contrast": 2
     },
-    "sort-chip-selected/dark": {
-      "color-contrast": 4
-    },
+    "sort-chip-selected/dark": {},
     "sort-chip-placed/light": {
       "color-contrast": 1
     },
-    "sort-chip-placed/dark": {
-      "color-contrast": 4
-    },
+    "sort-chip-placed/dark": {},
     "mcq-unanswered/light": {},
     "mcq-unanswered/dark": {},
     "matrix-unanswered/light": {},

--- a/public/modules/matching.css
+++ b/public/modules/matching.css
@@ -27,9 +27,9 @@
     --Colors-Learn-Practice-Selection-Area-Placeholder: var(--Colors-Text-Body-Default);
     --Colors-Learn-Practice-Choice-Background-Used: var(--Colors-Backgrounds-Main-Medium);
     --Colors-Learn-Practice-Choice-Label-Used: var(--Colors-Text-Body-Medium);
-    --Colors-Learn-Practice-Interactive-Choice-Main-Background: var(--Colors-Base-Accent-Sky-Blue-700);
+    --Colors-Learn-Practice-Interactive-Choice-Main-Background: var(--Colors-Base-Accent-Sky-Blue-900);
     --Colors-Learn-Practice-Interactive-Choice-Main-Label: var(--Colors-Base-Neutral-00);
-    --Colors-Learn-Practice-Interactive-Choice-Main-Background-Hover: var(--Colors-Base-Accent-Sky-Blue-600);
+    --Colors-Learn-Practice-Interactive-Choice-Main-Background-Hover: var(--Colors-Base-Accent-Sky-Blue-1000);
   }
 }
 

--- a/public/modules/sort.css
+++ b/public/modules/sort.css
@@ -16,9 +16,9 @@
 @media (prefers-color-scheme: dark) {
   :root {
     --Colors-Learn-Practice-Card: var(--Colors-Backgrounds-Main-Light);
-    --Colors-Learn-Practice-Interactive-Choice-Main-Background: var(--Colors-Base-Accent-Sky-Blue-700);
+    --Colors-Learn-Practice-Interactive-Choice-Main-Background: var(--Colors-Base-Accent-Sky-Blue-900);
     --Colors-Learn-Practice-Interactive-Choice-Main-Label: var(--Colors-Base-Neutral-00);
-    --Colors-Learn-Practice-Interactive-Choice-Main-Background-Hover: var(--Colors-Base-Accent-Sky-Blue-600);
+    --Colors-Learn-Practice-Interactive-Choice-Main-Background-Hover: var(--Colors-Base-Accent-Sky-Blue-1000);
     /* Elevate the empty fill above the page/card so slots stay visible. */
     --Colors-Learn-Practice-Interactive-Choice-Main-Background-Empty: var(--Colors-Backgrounds-Main-Medium);
   }

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -17,6 +17,63 @@ function sliceFn(src, name) {
   return src.slice(start, end);
 }
 
+// Same WCAG relative-luminance / contrast math as a11y-audits/tools/lib/page-checks.js.
+function hexToRgb(hex) {
+  const n = hex.replace('#', '');
+  return [0, 2, 4].map((i) => parseInt(n.slice(i, i + 2), 16));
+}
+
+function relLum(rgb) {
+  const f = (c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * f(rgb[0]) + 0.7152 * f(rgb[1]) + 0.0722 * f(rgb[2]);
+}
+
+function contrastRatio(a, b) {
+  const l1 = relLum(a);
+  const l2 = relLum(b);
+  const hi = Math.max(l1, l2);
+  const lo = Math.min(l1, l2);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+function baseColorHex() {
+  const css = read('public/design-system/colors/colors.css');
+  const map = {};
+  const re = /(--Colors-Base-[A-Za-z0-9-]+):\s*(#[0-9A-Fa-f]{6})\b/g;
+  let m;
+  while ((m = re.exec(css))) map[m[1]] = m[2];
+  return map;
+}
+
+function darkChoiceAliases(css) {
+  const dark = css.slice(css.indexOf('@media (prefers-color-scheme: dark)'));
+  const alias = (prop) => {
+    const m = dark.match(new RegExp(`${prop}:\\s*var\\((--Colors-Base-[A-Za-z0-9-]+)\\)`));
+    assert.ok(m, `dark ${prop} must alias a --Colors-Base-* token`);
+    return m[1];
+  };
+  return {
+    fg: alias('--Colors-Learn-Practice-Interactive-Choice-Main-Label'),
+    bg: alias('--Colors-Learn-Practice-Interactive-Choice-Main-Background'),
+    hover: alias('--Colors-Learn-Practice-Interactive-Choice-Main-Background-Hover')
+  };
+}
+
+function assertChoiceContrast(file, hex, aliases, which, token) {
+  const fg = hex[aliases.fg];
+  const bg = hex[token];
+  assert.ok(fg, `${file}: unresolved ${aliases.fg}`);
+  assert.ok(bg, `${file}: unresolved ${token}`);
+  const ratio = contrastRatio(hexToRgb(fg), hexToRgb(bg));
+  assert.ok(
+    ratio + 0.01 >= 4.5,
+    `${file} dark ${which} ${aliases.fg} (${fg}) on ${token} (${bg}) is ${ratio.toFixed(2)}:1, need 4.5:1`
+  );
+}
+
 test('A1: #activity-container is not a live region', () => {
   const html = read('public/index.html');
   const open = html.match(/<div id="activity-container"[^>]*>/);
@@ -176,29 +233,11 @@ test('A11: Matching choices are a labeled group of buttons', () => {
   assert.match(src, /choiceButton\.disabled\s*=\s*true/);
 });
 
-test('A7: dark choice tokens use a 4.5:1 sky-blue pair', () => {
+test('A7: dark choice default and hover contrast are at least 4.5:1', () => {
+  const hex = baseColorHex();
   for (const file of ['public/modules/matching.css', 'public/modules/sort.css']) {
-    const src = read(file);
-    const dark = src.slice(src.indexOf('@media (prefers-color-scheme: dark)'));
-    assert.match(
-      dark,
-      /--Colors-Learn-Practice-Interactive-Choice-Main-Background:\s*var\(--Colors-Base-Accent-Sky-Blue-900\)/,
-      `${file} dark background is Sky-Blue-900 (white text is 5.7:1)`
-    );
-    assert.match(
-      dark,
-      /--Colors-Learn-Practice-Interactive-Choice-Main-Label:\s*var\(--Colors-Base-Neutral-00\)/,
-      `${file} dark label stays Neutral-00`
-    );
-    assert.match(
-      dark,
-      /--Colors-Learn-Practice-Interactive-Choice-Main-Background-Hover:\s*var\(--Colors-Base-Accent-Sky-Blue-1000\)/,
-      `${file} dark hover is Sky-Blue-1000 (white text is 8.5:1)`
-    );
-    assert.doesNotMatch(
-      dark,
-      /Interactive-Choice-Main-Background:\s*var\(--Colors-Base-Accent-Sky-Blue-700\)/,
-      `${file} must not keep the failing Sky-Blue-700 fill`
-    );
+    const aliases = darkChoiceAliases(read(file));
+    assertChoiceContrast(file, hex, aliases, 'fill', aliases.bg);
+    assertChoiceContrast(file, hex, aliases, 'hover', aliases.hover);
   }
 });

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -175,3 +175,30 @@ test('A11: Matching choices are a labeled group of buttons', () => {
   assert.match(src, /createElement\('button'\)/);
   assert.match(src, /choiceButton\.disabled\s*=\s*true/);
 });
+
+test('A7: dark choice tokens use a 4.5:1 sky-blue pair', () => {
+  for (const file of ['public/modules/matching.css', 'public/modules/sort.css']) {
+    const src = read(file);
+    const dark = src.slice(src.indexOf('@media (prefers-color-scheme: dark)'));
+    assert.match(
+      dark,
+      /--Colors-Learn-Practice-Interactive-Choice-Main-Background:\s*var\(--Colors-Base-Accent-Sky-Blue-900\)/,
+      `${file} dark background is Sky-Blue-900 (white text is 5.7:1)`
+    );
+    assert.match(
+      dark,
+      /--Colors-Learn-Practice-Interactive-Choice-Main-Label:\s*var\(--Colors-Base-Neutral-00\)/,
+      `${file} dark label stays Neutral-00`
+    );
+    assert.match(
+      dark,
+      /--Colors-Learn-Practice-Interactive-Choice-Main-Background-Hover:\s*var\(--Colors-Base-Accent-Sky-Blue-1000\)/,
+      `${file} dark hover is Sky-Blue-1000 (white text is 8.5:1)`
+    );
+    assert.doesNotMatch(
+      dark,
+      /Interactive-Choice-Main-Background:\s*var\(--Colors-Base-Accent-Sky-Blue-700\)/,
+      `${file} must not keep the failing Sky-Blue-700 fill`
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Dark Matching choice buttons, matched selection areas, and Sort chips now meet 4.5:1 (audit A7, WCAG 1.4.3). Light is unchanged.

Closes #33.

## Changes

The app Learn-Practice choice pair is duplicated in `matching.css` and `sort.css`. Dark was Sky-Blue-700 fill with white text (2.89:1 on chips). Both files now use Sky-Blue-900 / Neutral-00 (5.7:1), with Sky-Blue-1000 on hover (8.5:1). Disabled Matching choices keep their used tokens and 1.4.3 exemption.

Axe `color-contrast` went 25 → 8. Remaining nodes are Matching inactive cards (D1) and Sort instructions in light (A8).

Also records A10 as closed (PR #41) on the issue map.

## Test plan

- [x] `npm test` (A7 characterization locks the dark Sky-Blue-900 / 1000 pair in both CSS files)
- [x] `npm run a11y:ci` then `WRITE_BASELINE=1 npm run a11y:ci` (`color-contrast` 25 → 8; light counts unchanged)
- [x] Manual: dark Matching choices and Sort chips; hover still readable; light unchanged
