### PR TITLE
Iframes | Allow clipboard copy and paste from simulations

### DIFF
--- a/public/examples-mode.html
+++ b/public/examples-mode.html
@@ -167,7 +167,7 @@
       <span id="status"></span>
     </div>
     <div id="frame-wrap">
-      <iframe id="app-frame" title="Activity preview" src="/play"></iframe>
+      <iframe id="app-frame" title="Activity preview" src="/play" allow="clipboard-read; clipboard-write"></iframe>
     </div>
   </div>
   <script>

--- a/public/utils/activity-content-shell.js
+++ b/public/utils/activity-content-shell.js
@@ -121,6 +121,7 @@ export function mountActivityContentShell({ container, content }) {
   leftPanel.className = 'activity-content-pane';
   const iframe = document.createElement('iframe');
   iframe.className = 'activity-content-iframe';
+  iframe.setAttribute('allow', 'clipboard-read; clipboard-write');
   iframe.setAttribute('frameborder', '1');
   const sideUrl = hasUrl ? String(content.url || '') : '';
   iframe.title = sideUrl === '/sim' || sideUrl.startsWith('/sim/') ? 'Simulation' : 'Reference';


### PR DESCRIPTION
## Summary

Side-content iframes (simulation, markdown reference, and external URL) can use the clipboard, so copy and paste inside a sim works.

## Changes

Permissions Policy does not grant clipboard to iframes by default. `.activity-content-iframe` now sets `allow="clipboard-read; clipboard-write"`.

The examples picker wraps `/play` in `#app-frame`. Nested iframes only get clipboard if every ancestor delegates it, so the picker iframe gets the same `allow` list.

## Test plan

- [x] `npm run examples`, pick a `/sim/` example, copy text from the simulation panel and paste it into a blank or text input
- [x] Same check on `/play` without the picker (`npm start` with a sim `question.md`)
