### PR TITLE
A11y | Raise Sort instruction contrast in light

### DIFF
--- a/a11y-audits/8-13-26/resolution-plan.md
+++ b/a11y-audits/8-13-26/resolution-plan.md
@@ -257,7 +257,7 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 | DS bump D1 | #30 | after D1 | | Blocked |
 | A2 | #31 | 2 | #40 | Closed (PR #40) |
 | A10 | #32 | 2 | #41 | Closed (PR #41) |
-| A7 | #33 | 3 | | Open |
+| A7 | #33 | 3 | #42 | Closed (PR #42) |
 | A8 | #34 | 3 | | Open |
 
 ---
@@ -273,4 +273,4 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 
 ## Next step
 
-P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). A3 is on `main` (PR #37). A9 is on `main` (PR #38). A11 is on `main` (PR #39). A2 is on `main` (PR #40). A10 is on `main` (PR #41). Wave 3 starts with A7 (`fix/a11y-choice-contrast`, #33), then A8 (#34).
+P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). A3 is on `main` (PR #37). A9 is on `main` (PR #38). A11 is on `main` (PR #39). A2 is on `main` (PR #40). A10 is on `main` (PR #41). A7 is on `main` (PR #42). Wave 3 continues with A8 (`fix/a11y-sort-instructions-contrast`, #34).

--- a/a11y-audits/tools/axe-baseline.json
+++ b/a11y-audits/tools/axe-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-20T10:48:13.981Z",
+  "generatedAt": "2026-08-21T18:41:04.778Z",
   "tags": [
     "wcag2a",
     "wcag2aa",
@@ -8,7 +8,7 @@
     "wcag22aa"
   ],
   "byRule": {
-    "color-contrast": 8
+    "color-contrast": 5
   },
   "byState": {
     "fib-unanswered/light": {},
@@ -21,17 +21,13 @@
     "matching-empty/dark": {
       "color-contrast": 2
     },
-    "sort-tray/light": {
-      "color-contrast": 1
-    },
+    "sort-tray/light": {},
     "sort-tray/dark": {},
     "sort-chip-selected/light": {
-      "color-contrast": 2
-    },
-    "sort-chip-selected/dark": {},
-    "sort-chip-placed/light": {
       "color-contrast": 1
     },
+    "sort-chip-selected/dark": {},
+    "sort-chip-placed/light": {},
     "sort-chip-placed/dark": {},
     "mcq-unanswered/light": {},
     "mcq-unanswered/dark": {},

--- a/public/modules/sort.css
+++ b/public/modules/sort.css
@@ -258,7 +258,7 @@
 }
 
 .categorization-instructions-text {
-  color: var(--Colors-Text-Body-Light);
+  color: var(--Colors-Text-Body-Default);
   text-align: center;
   margin: 0;
 }

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -241,3 +241,42 @@ test('A7: dark choice default and hover contrast are at least 4.5:1', () => {
     assertChoiceContrast(file, hex, aliases, 'hover', aliases.hover);
   }
 });
+
+test('A8: Sort instructions meet 4.5:1 in light and keep the click-or-drag copy', () => {
+  const sortJs = read('public/modules/sort.js');
+  assert.match(
+    sortJs,
+    /Click or drag the items onto the cards above/,
+    'instruction copy stays put (P8 / A14 is out of this plan)'
+  );
+
+  const sortCss = read('public/modules/sort.css');
+  const colorM = sortCss.match(
+    /\.categorization-instructions-text\s*\{[^}]*color:\s*var\((--Colors-Text-Body-[A-Za-z]+)\)/
+  );
+  assert.ok(colorM, 'instructions text sets a Body color token');
+  assert.notEqual(
+    colorM[1],
+    '--Colors-Text-Body-Lighter',
+    'body-xxsmall must not use Body-Lighter'
+  );
+
+  const colorsCss = read('public/design-system/colors/colors.css');
+  const light = colorsCss.slice(0, colorsCss.indexOf('@media (prefers-color-scheme: dark)'));
+  const resolve = (prop) => {
+    const m = light.match(new RegExp(`${prop}:\\s*var\\((--Colors-Base-[A-Za-z0-9-]+)\\)`));
+    assert.ok(m, `light ${prop} aliases a base token`);
+    return m[1];
+  };
+  const hex = baseColorHex();
+  const fgToken = resolve(colorM[1]);
+  const bgToken = resolve('--Colors-Backgrounds-Main-Default');
+  const fg = hex[fgToken];
+  const bg = hex[bgToken];
+  assert.ok(fg && bg, `unresolved ${fgToken} or ${bgToken}`);
+  const ratio = contrastRatio(hexToRgb(fg), hexToRgb(bg));
+  assert.ok(
+    ratio + 0.01 >= 4.5,
+    `instructions ${colorM[1]} (${fg}) on Main-Default (${bg}) is ${ratio.toFixed(2)}:1, need 4.5:1`
+  );
+});


### PR DESCRIPTION
## Summary

Sort instructions (“Click or drag the items onto the cards above”) now meet 4.5:1 in light (audit A8, WCAG 1.4.3). Copy is unchanged. Dark is unchanged.

Closes #34.

## Changes

`.categorization-instructions-text.body-xxsmall` was `Text-Body-Light` (Neutral-900) on the Sort `Main-Default` background (Neutral-50): **4.46:1**. The audit named `Body-Lighter`; the painted token was already `Light`, which still misses AA at this size.

The line now uses `Text-Body-Default` (**10.66:1**). Wording is the existing P8 string.

Axe `color-contrast` went **8 → 5**. Remaining nodes are Matching inactive cards (D1) and one Sort `chip-selected` light node (empty dropzone placeholder, out of A8).

Also records A7 as closed (PR #42) on the issue map.

## Test plan

- [x] `npm test` (A8 characterization locks the instruction token at ≥4.5:1 on light Main-Default and keeps the click-or-drag copy)
- [x] `npm run a11y:ci` then `WRITE_BASELINE=1 npm run a11y:ci` (`color-contrast` 8 → 5; Sort light tray/placed instructions cleared)
- [x] Manual: Sort light, confirm the instruction line is darker and still reads “Click or drag the items onto the cards above”
- [x] Spot-check Sort dark so A7 chips did not regress
