### PR TITLE
Sort | Restore Founders Grotesk on category headings

### DIFF
--- a/public/modules/sort.css
+++ b/public/modules/sort.css
@@ -88,8 +88,8 @@
   width: 100%;
   margin: 0;
   box-sizing: border-box;
-  font: inherit;
-  font-family: inherit;
+  /* Leave font to .heading-small. font: inherit here wins the cascade and
+     falls back to Times because body has no font-family. */
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary

Category headings on Sort-into-boxes went to Times after the Aug 17 a11y pass turned the heading into a button. `.heading-small` is Founders Grotesk again.

## Changes

The button reset used `font: inherit` / `font-family: inherit`. Same specificity as `.heading-small`, later in `sort.css`, so inherit won. `body` has no font-family, so the UA serif (Times) showed up.

Those two declarations are gone. Other button resets stay so keyboard placement still works.

## Test plan

- [x] Open Sort-into-boxes (`sort-into-boxes.md` at `/play`)
- [x] Confirm category titles render in Founders Grotesk, 24px / 500
- [x] Select a chip and activate a category heading (click or Enter/Space); placement should still work
- [x] Keyboard-focus a category heading and confirm the drop-target highlight still appears
