### PR TITLE
A11y | Bump design-system for D2 split divider

### DIFF
--- a/a11y-audits/8-13-26/resolution-plan.md
+++ b/a11y-audits/8-13-26/resolution-plan.md
@@ -253,12 +253,12 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 | A11 | #28 | 1 | #39 | Closed (PR #39) |
 | D2 | [DS #28](https://github.com/CodeSignal/learn_bespoke-design-system/issues/28) | 1 ∥ | | Open |
 | D1 | [DS #29](https://github.com/CodeSignal/learn_bespoke-design-system/issues/29) | 1 ∥ / 3 | | Open |
-| DS bump D2 | #29 | after D2 | | Blocked |
+| DS bump D2 | #29 | after D2 | | Open |
 | DS bump D1 | #30 | after D1 | | Blocked |
 | A2 | #31 | 2 | #40 | Closed (PR #40) |
 | A10 | #32 | 2 | #41 | Closed (PR #41) |
 | A7 | #33 | 3 | #42 | Closed (PR #42) |
-| A8 | #34 | 3 | | Open |
+| A8 | #34 | 3 | #44 | Closed (PR #44) |
 
 ---
 
@@ -273,4 +273,4 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 
 ## Next step
 
-P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). A3 is on `main` (PR #37). A9 is on `main` (PR #38). A11 is on `main` (PR #39). A2 is on `main` (PR #40). A10 is on `main` (PR #41). A7 is on `main` (PR #42). Wave 3 continues with A8 (`fix/a11y-sort-instructions-contrast`, #34).
+P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). A3 is on `main` (PR #37). A9 is on `main` (PR #38). A11 is on `main` (PR #39). A2 is on `main` (PR #40). A10 is on `main` (PR #41). A7 is on `main` (PR #42). A8 is on `main` (PR #44). D2 is merged in the design system (DS PR #30); consume it via #29. D1 remains [DS #29](https://github.com/CodeSignal/learn_bespoke-design-system/issues/29), then bump #30.

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -280,3 +280,17 @@ test('A8: Sort instructions meet 4.5:1 in light and keep the click-or-drag copy'
     `instructions ${colorM[1]} (${fg}) on Main-Default (${bg}) is ${ratio.toFixed(2)}:1, need 4.5:1`
   );
 });
+
+test('D2: split divider is named and uses a 24px pointer target', () => {
+  const js = read('public/design-system/components/split-panel/split-panel.js');
+  assert.match(js, /['"]Resize reference panel['"]/);
+  assert.match(js, /setAttribute\('aria-label'/);
+
+  const css = read('public/design-system/components/split-panel/split-panel.css');
+  const container = css.match(/\.split-panel-container\s*\{[^}]+\}/);
+  assert.ok(container, 'container rule exists');
+  assert.doesNotMatch(container[0], /min-width:\s*24px/);
+  assert.doesNotMatch(container[0], /min-height:\s*24px/);
+  assert.match(css, /padding:\s*0 10px/);
+  assert.match(css, /\.split-panel-divider\s*\{[\s\S]*?min-height:\s*24px/);
+});


### PR DESCRIPTION
## Summary
Closes #29. This app now consumes the design-system D2 Split Panel divider (named, ≥24×24 CSS px pointer target). Keyboard resize is unchanged.

Also records A8 as closed (PR #44) on the issue map. That number is not on the D2 or bump rows.

## Changes
Submodule `public/design-system` points at `d0604a8` (DS PR #30). No app widget changes.

Characterization locks the English `aria-label` (“Resize reference panel”) and the 24px hit-area CSS so a later submodule pin cannot drop D2 silently.

## Test plan
- [x] `npm test` (includes D2 characterization)
- [x] `npm run a11y:ci` on a dedicated examples port (`color-contrast` stayed 5; `shell-split-markdown` light and dark had 0 violations)
- [ ] Optional: `/play` with `side-content-markdown-table.md`, confirm the divider name and that arrow keys still resize
