### PR TITLE
A11y | Bump design-system for D1 card contrast

### DIFF
--- a/a11y-audits/8-13-26/resolution-plan.md
+++ b/a11y-audits/8-13-26/resolution-plan.md
@@ -251,10 +251,10 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 | A3 | #26 | 1 | #37 | Closed (PR #37) |
 | A9 | #27 | 1 | #38 | Closed (PR #38) |
 | A11 | #28 | 1 | #39 | Closed (PR #39) |
-| D2 | [DS #28](https://github.com/CodeSignal/learn_bespoke-design-system/issues/28) | 1 ∥ | | Open |
+| D2 | [DS #28](https://github.com/CodeSignal/learn_bespoke-design-system/issues/28) | 1 ∥ | #46 | Closed (PR #46) |
 | D1 | [DS #29](https://github.com/CodeSignal/learn_bespoke-design-system/issues/29) | 1 ∥ / 3 | | Open |
-| DS bump D2 | #29 | after D2 | | Open |
-| DS bump D1 | #30 | after D1 | | Blocked |
+| DS bump D2 | #29 | after D2 | #46 | Closed (PR #46) |
+| DS bump D1 | #30 | after D1 | | Open |
 | A2 | #31 | 2 | #40 | Closed (PR #40) |
 | A10 | #32 | 2 | #41 | Closed (PR #41) |
 | A7 | #33 | 3 | #42 | Closed (PR #42) |
@@ -273,4 +273,4 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 
 ## Next step
 
-P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). A3 is on `main` (PR #37). A9 is on `main` (PR #38). A11 is on `main` (PR #39). A2 is on `main` (PR #40). A10 is on `main` (PR #41). A7 is on `main` (PR #42). A8 is on `main` (PR #44). D2 is merged in the design system (DS PR #30); consume it via #29. D1 remains [DS #29](https://github.com/CodeSignal/learn_bespoke-design-system/issues/29), then bump #30.
+P1–P7 confirmed as the recommended defaults. Wave 0 is on `main` (PR #20). A1 is on `main` (PR #35). Sort bundle is on `main` (PR #36). A3 is on `main` (PR #37). A9 is on `main` (PR #38). A11 is on `main` (PR #39). A2 is on `main` (PR #40). A10 is on `main` (PR #41). A7 is on `main` (PR #42). A8 is on `main` (PR #44). D2 is on `main` (PR #46). D1 is merged in the design system (DS PR #31); consume it via #30.

--- a/a11y-audits/tools/axe-baseline.json
+++ b/a11y-audits/tools/axe-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-21T18:41:04.778Z",
+  "generatedAt": "2026-08-28T15:59:49.339Z",
   "tags": [
     "wcag2a",
     "wcag2aa",
@@ -8,19 +8,15 @@
     "wcag22aa"
   ],
   "byRule": {
-    "color-contrast": 5
+    "color-contrast": 1
   },
   "byState": {
     "fib-unanswered/light": {},
     "fib-unanswered/dark": {},
     "fib-dropdown-open/light": {},
     "fib-dropdown-open/dark": {},
-    "matching-empty/light": {
-      "color-contrast": 2
-    },
-    "matching-empty/dark": {
-      "color-contrast": 2
-    },
+    "matching-empty/light": {},
+    "matching-empty/dark": {},
     "sort-tray/light": {},
     "sort-tray/dark": {},
     "sort-chip-selected/light": {

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -281,6 +281,19 @@ test('A8: Sort instructions meet 4.5:1 in light and keep the click-or-drag copy'
   );
 });
 
+test('D1: inactive cards keep full-contrast text', () => {
+  const css = read('public/design-system/components/horizontal-cards/horizontal-cards.css');
+  const inactive = css.match(
+    /\.horizontal-cards-card:not\(\.horizontal-cards-card-active\)\s*\{[^}]+\}/
+  );
+  assert.ok(inactive, 'inactive card rule exists');
+  assert.doesNotMatch(inactive[0], /opacity\s*:/);
+  assert.match(inactive[0], /box-shadow:\s*inset/);
+
+  const js = read('public/design-system/components/horizontal-cards/horizontal-cards.js');
+  assert.doesNotMatch(js, /aria-hidden/);
+});
+
 test('D2: split divider is named and uses a 24px pointer target', () => {
   const js = read('public/design-system/components/split-panel/split-panel.js');
   assert.match(js, /['"]Resize reference panel['"]/);


### PR DESCRIPTION
## Summary
Closes #30. This app now consumes the design-system D1 Horizontal Cards change: inactive card text stays at ≥4.5:1; chrome (inset stroke vs drop shadow) marks the centered card.

Also records D2 as closed (PR #46) on the issue map. That number is not on the D1 or bump D1 rows.

## Changes
Submodule `public/design-system` points at `da75b17` (DS PR #31). No app widget changes.

Characterization locks the inactive-card rule so it cannot regain `opacity`, and so cards are not `aria-hidden`.

Axe floor `color-contrast` is 5 → 1. Matching empty is clear in both themes. The remaining node is the Sort empty-dropzone placeholder (`Body-Lighter`), which is not an audit ID.

## Test plan
- [x] `npm test` (includes D1 characterization)
- [x] `npm run a11y:ci` on a dedicated examples port (`matching-empty` light and dark had 0 violations)
- [x] Optional: `/play` with `matching.md`, confirm side cards still read as side cards and text is full contrast
