### PR TITLE
A11y | Name the MCQ fieldset

### DIFF
--- a/a11y-audits/8-13-26/wave-4-plan.md
+++ b/a11y-audits/8-13-26/wave-4-plan.md
@@ -4,7 +4,7 @@
 **Program:** [program-plan.md](./program-plan.md)  
 **Critical / serious:** [resolution-plan.md](./resolution-plan.md) (A1–A11, D1–D2 on `main`)  
 **Standard:** WCAG 2.2 AA  
-**Status:** Product calls P8–P15 confirmed. Issues filed. A17 on `main` (PR #60). D3 bump on `main` (PR #61). Executing Wave 4a A16.
+**Status:** Product calls P8–P15 confirmed. Issues filed. A16 on `main` (PR #62). Executing Wave 4a A18.
 
 In scope: **A12–A20, D3**, and leftover axe **A21**.  
 Out of this plan: A1–A11, D1, D2. Do not reopen them. Do not retune A7 Learn-Practice choice tokens. Question editor stays out (internal-only).
@@ -28,6 +28,7 @@ Out of this plan: A1–A11, D1, D2. Do not reopen them. Do not retune A7 Learn-P
 | D2 | DS #30 → app #46 | Divider **name** + ≥24×24 hit target. Line color left for D3. |
 | D1 | DS #31 → app #48 | Inactive cards: chrome fade (inset stroke), not `opacity`, not `aria-hidden`, not `scale()` |
 | A17 | #60 | Drop Matrix `role="grid"` |
+| A16 | #62 | Scroll indicator `aria-hidden` |
 | D3 | DS #33 → app #61 | Divider line token (Neutral-800), ≥3:1 vs panes |
 
 Unrelated merges on the same timeline: clipboard in iframes (#43), Sort heading font (#45). Not audit IDs.
@@ -253,7 +254,7 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 | A13 | #50 | 4a | | Open |
 | A14 | #51 | 4b | | Open |
 | A15 | #52 | 4a | | Open |
-| A16 | #53 | 4a | | Open |
+| A16 | #53 | 4a | #62 | Closed (PR #62) |
 | A17 | #54 | 4a | #60 | Closed (PR #60) |
 | A18 | #55 | 4a | | Open |
 | A19 | #56 | 4b | | Open |
@@ -277,4 +278,4 @@ Critical/serious rows stay in [resolution-plan.md](./resolution-plan.md). The do
 
 ## Next step
 
-D3 / bump D3 are on `main` (PR #61). Next after A16: Wave 4a A18 (`fix/a11y-mcq-fieldset`, #55). Do not put #61 on the A16 row.
+A16 is on `main` (PR #62). Next after A18: Wave 4a A15 (`fix/a11y-text-input-next`, #52). Do not put #62 on the A18 row.

--- a/public/modules/mcq.css
+++ b/public/modules/mcq.css
@@ -206,6 +206,7 @@
   flex-direction: column;
   gap: var(--UI-Spacing-spacing-xl, 32px);
   min-width: 0;
+  position: relative;
 }
 
 .mcq-option-text {
@@ -239,7 +240,16 @@
 }
 
 .mcq-option-label {
-  display: none; /* Option labels (A, B, C) are not shown in the design */
+  /* Visually hidden; still in the wrapping label's accessible name. */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .mcq-next-button-container {

--- a/public/modules/mcq.js
+++ b/public/modules/mcq.js
@@ -113,17 +113,20 @@ export function initMcq({
     questionEl.setAttribute('data-question-index', qIdx.toString());
     
     // Question legend — custom __Question Name__ or "Question N" when multiple questions
+    let questionLegendEl = null;
     if (hasMultipleQuestions) {
-      const legend = document.createElement('div');
-      legend.className = 'mcq-legend heading-xsmall';
+      questionLegendEl = document.createElement('div');
+      questionLegendEl.className = 'mcq-legend heading-xsmall';
+      questionLegendEl.id = `q${question.id}-legend`;
       const customName = question.name && String(question.name).trim();
-      legend.textContent = customName || `Question ${qIdx + 1}`;
-      questionEl.appendChild(legend);
+      questionLegendEl.textContent = customName || `Question ${qIdx + 1}`;
+      questionEl.appendChild(questionLegendEl);
     }
     
     // Question text (support markdown HTML if available, fallback to plain text for backward compatibility)
     const questionTextEl = document.createElement('div');
     questionTextEl.className = 'mcq-question-text body-large markdown-content';
+    questionTextEl.id = `q${question.id}-text`;
     if (question.textHtml) {
       questionTextEl.innerHTML = question.textHtml;
       // Render LaTeX math expressions
@@ -136,6 +139,10 @@ export function initMcq({
     // Options container
     const optionsEl = document.createElement('fieldset');
     optionsEl.className = 'mcq-options';
+    const fieldsetNameIds = [];
+    if (questionLegendEl) fieldsetNameIds.push(questionLegendEl.id);
+    fieldsetNameIds.push(questionTextEl.id);
+    optionsEl.setAttribute('aria-labelledby', fieldsetNameIds.join(' '));
     
     // Create options
     question.options.forEach((option, optIdx) => {
@@ -151,7 +158,6 @@ export function initMcq({
       input.name = `question-${question.id}`;
       input.value = displayLabel;
       input.id = `q${question.id}-opt${optIdx}`;
-      input.setAttribute('aria-label', `Option ${displayLabel}: ${option.text}`);
       
       const optionText = document.createElement('div');
       optionText.className = 'mcq-option-text body-large markdown-content';

--- a/public/modules/mcq.js
+++ b/public/modules/mcq.js
@@ -192,6 +192,7 @@ export function initMcq({
         // Text wrapper
         const textWrapper = document.createElement('div');
         textWrapper.className = 'mcq-option-content';
+        textWrapper.appendChild(optionLabel);
         textWrapper.appendChild(optionText);
         
         optionCard.appendChild(checkboxBox);
@@ -209,6 +210,7 @@ export function initMcq({
         // Text wrapper
         const textWrapper = document.createElement('div');
         textWrapper.className = 'mcq-option-content';
+        textWrapper.appendChild(optionLabel);
         textWrapper.appendChild(optionText);
         
         optionCard.appendChild(radioCircle);

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -308,6 +308,13 @@ test('A16: scroll indicator is hidden from AT', () => {
   assert.doesNotMatch(init, /scroll for more/i);
 });
 
+test('A18: MCQ fieldset is named from existing question UI; options use the visible label', () => {
+  const src = read('public/modules/mcq.js');
+  assert.match(src, /createElement\('fieldset'\)/);
+  assert.match(src, /setAttribute\(\s*'aria-labelledby'/);
+  assert.doesNotMatch(src, /aria-label['"],\s*`Option /);
+});
+
 test('D2: split divider is named and uses a 24px pointer target', () => {
   const js = read('public/design-system/components/split-panel/split-panel.js');
   assert.match(js, /['"]Resize reference panel['"]/);

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -310,9 +310,33 @@ test('A16: scroll indicator is hidden from AT', () => {
 
 test('A18: MCQ fieldset is named from existing question UI; options use the visible label', () => {
   const src = read('public/modules/mcq.js');
-  assert.match(src, /createElement\('fieldset'\)/);
-  assert.match(src, /setAttribute\(\s*'aria-labelledby'/);
+  assert.match(src, /questionLegendEl\.id = `q\$\{question\.id\}-legend`/);
+  assert.match(src, /questionTextEl\.id = `q\$\{question\.id\}-text`/);
+  assert.match(src, /fieldsetNameIds\.push\(questionLegendEl\.id\)/);
+  assert.match(src, /fieldsetNameIds\.push\(questionTextEl\.id\)/);
+  assert.match(
+    src,
+    /setAttribute\(\s*'aria-labelledby',\s*fieldsetNameIds\.join\(' '\)\)/
+  );
   assert.doesNotMatch(src, /aria-label['"],\s*`Option /);
+
+  const labelAttaches = src.match(/textWrapper\.appendChild\(optionLabel\)/g);
+  assert.equal(
+    labelAttaches && labelAttaches.length,
+    2,
+    'checkbox and radio branches must both attach optionLabel (letter) next to optionText'
+  );
+  assert.match(src, /optionLabel\.textContent = displayLabel \+ '\.'/);
+
+  const css = read('public/modules/mcq.css');
+  const labelRule = css.match(/\.mcq-option-label\s*\{[^}]+\}/);
+  assert.ok(labelRule, '.mcq-option-label rule exists');
+  assert.doesNotMatch(
+    labelRule[0],
+    /display\s*:\s*none/,
+    'display:none would drop the option letter from the wrapping label AccName'
+  );
+  assert.match(labelRule[0], /clip:\s*rect/);
 });
 
 test('D2: split divider is named and uses a 24px pointer target', () => {


### PR DESCRIPTION
## Summary
Closes #55. The MCQ options fieldset takes its accessible name from the existing question text (and the multi-question heading when that is present). Option radios/checkboxes use the visible label instead of a redundant `aria-label`.

Also records A16 as closed (PR #62) on the issue map. That number is not on the A18 row.

## Changes
`aria-labelledby` points at the question text node, plus `.mcq-legend` when there are multiple questions. The wrapping `<label>` already exposes the visible option text, so `aria-label="Option A: …"` is gone (2.5.3). No new copy.

## Test plan
- [x] `npm test` — A18 characterization
- [ ] `mcq.md` and `mcq-2-questions.md` in light and dark: fieldset name matches the question; option name matches the visible text
