### PR TITLE
A11y | Mount the Text Input Next button

### DIFF
--- a/a11y-audits/8-13-26/wave-4-plan.md
+++ b/a11y-audits/8-13-26/wave-4-plan.md
@@ -4,7 +4,7 @@
 **Program:** [program-plan.md](./program-plan.md)  
 **Critical / serious:** [resolution-plan.md](./resolution-plan.md) (A1–A11, D1–D2 on `main`)  
 **Standard:** WCAG 2.2 AA  
-**Status:** Product calls P8–P15 confirmed. Issues filed. A16 on `main` (PR #62). Executing Wave 4a A18.
+**Status:** Product calls P8–P15 confirmed. Issues filed. A18 on `main` (PR #63). Executing Wave 4a A15.
 
 In scope: **A12–A20, D3**, and leftover axe **A21**.  
 Out of this plan: A1–A11, D1, D2. Do not reopen them. Do not retune A7 Learn-Practice choice tokens. Question editor stays out (internal-only).
@@ -29,6 +29,7 @@ Out of this plan: A1–A11, D1, D2. Do not reopen them. Do not retune A7 Learn-P
 | D1 | DS #31 → app #48 | Inactive cards: chrome fade (inset stroke), not `opacity`, not `aria-hidden`, not `scale()` |
 | A17 | #60 | Drop Matrix `role="grid"` |
 | A16 | #62 | Scroll indicator `aria-hidden` |
+| A18 | #63 | MCQ fieldset named from question UI |
 | D3 | DS #33 → app #61 | Divider line token (Neutral-800), ≥3:1 vs panes |
 
 Unrelated merges on the same timeline: clipboard in iframes (#43), Sort heading font (#45). Not audit IDs.
@@ -256,7 +257,7 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 | A15 | #52 | 4a | | Open |
 | A16 | #53 | 4a | #62 | Closed (PR #62) |
 | A17 | #54 | 4a | #60 | Closed (PR #60) |
-| A18 | #55 | 4a | | Open |
+| A18 | #55 | 4a | #63 | Closed (PR #63) |
 | A19 | #56 | 4b | | Open |
 | A20 | #57 | 4a | | Open |
 | A21 | #58 | 4b | | Open |
@@ -278,4 +279,4 @@ Critical/serious rows stay in [resolution-plan.md](./resolution-plan.md). The do
 
 ## Next step
 
-A16 is on `main` (PR #62). Next after A18: Wave 4a A15 (`fix/a11y-text-input-next`, #52). Do not put #62 on the A18 row.
+A18 is on `main` (PR #63). Next after A15: Wave 4a A13 (`fix/a11y-toolbar-landmark`, #50). Do not put #63 on the A15 row.

--- a/public/modules/text-input.js
+++ b/public/modules/text-input.js
@@ -584,6 +584,7 @@ export function initTextInput({
         nextButton.disabled = !hasAnswer;
       });
       
+      nextButtonContainer.appendChild(nextButton);
       inputContainer.appendChild(nextButtonContainer);
     }
     questionEl.appendChild(inputContainer);

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -300,6 +300,15 @@ test('A17: Matrix table is a native table, not role=grid', () => {
   assert.doesNotMatch(src, /role="grid"/);
 });
 
+test('A15: Text Input Next button is mounted for non-last questions', () => {
+  const src = read('public/modules/text-input.js');
+  assert.match(src, /qIdx < textInput\.questions\.length - 1/);
+  assert.match(src, /className = 'button button-primary text-input-next-button'/);
+  assert.match(src, /nextButtonContainer\.appendChild\(nextButton\)/);
+  assert.match(src, /textContent = 'Next'/);
+  assert.match(src, /setAttribute\(\s*'aria-label',\s*`Go to next question`\)/);
+});
+
 test('A16: scroll indicator is hidden from AT', () => {
   const src = read('public/app.js');
   const init = sliceFn(src, 'initScrollIndicator');


### PR DESCRIPTION
## Summary
Closes #52. Non-last Text Input questions now mount the Next button that was already built. Clicking it focuses the next question's input, same pattern as MCQ.

Also records A18 as closed (PR #63) on the issue map. That number is not on the A15 row.

## Changes
The button and container were created for every non-last question; only the empty container was appended. `nextButtonContainer.appendChild(nextButton)` puts the existing "Next" / "Go to next question" control in the DOM. No `explainAnswer` gate. No new copy.

## Test plan
- [x] `npm test` — A15 characterization
- [x] `text-input-advanced.md` in light: 6 Next buttons for 7 questions; fill Q1, Next focuses Q2; last question has no Next
- [x] Dark: same Next control (DS primary button)
