### PR TITLE
A11y | Add a designed focus ring on blanks and toolbar tools

### DIFF
--- a/a11y-audits/8-13-26/wave-4-plan.md
+++ b/a11y-audits/8-13-26/wave-4-plan.md
@@ -4,7 +4,7 @@
 **Program:** [program-plan.md](./program-plan.md)  
 **Critical / serious:** [resolution-plan.md](./resolution-plan.md) (A1–A11, D1–D2 on `main`)  
 **Standard:** WCAG 2.2 AA  
-**Status:** Product calls P8–P15 confirmed. Issues filed. A15 on `main` (PR #64). Executing Wave 4a A13.
+**Status:** Product calls P8–P15 confirmed. Issues filed. A13 on `main` (PR #65). Executing Wave 4a A20.
 
 In scope: **A12–A20, D3**, and leftover axe **A21**.  
 Out of this plan: A1–A11, D1, D2. Do not reopen them. Do not retune A7 Learn-Practice choice tokens. Question editor stays out (internal-only).
@@ -31,6 +31,7 @@ Out of this plan: A1–A11, D1, D2. Do not reopen them. Do not retune A7 Learn-P
 | A16 | #62 | Scroll indicator `aria-hidden` |
 | A18 | #63 | MCQ fieldset named from question UI |
 | A15 | #64 | Text Input Next button mounted |
+| A13 | #65 | Toolbar inside `<main>` |
 | D3 | DS #33 → app #61 | Divider line token (Neutral-800), ≥3:1 vs panes |
 
 Unrelated merges on the same timeline: clipboard in iframes (#43), Sort heading font (#45). Not audit IDs.
@@ -253,7 +254,7 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 | D1 | [DS #29](https://github.com/CodeSignal/learn_bespoke-design-system/issues/29) | 1 ∥ / 3 | #48 | Closed (PR #48) |
 | DS bump D1 | #30 | after D1 | #48 | Closed (PR #48) |
 | A12 | #49 | 4b | | Open |
-| A13 | #50 | 4a | | Open |
+| A13 | #50 | 4a | #65 | Closed (PR #65) |
 | A14 | #51 | 4b | | Open |
 | A15 | #52 | 4a | #64 | Closed (PR #64) |
 | A16 | #53 | 4a | #62 | Closed (PR #62) |
@@ -280,4 +281,4 @@ Critical/serious rows stay in [resolution-plan.md](./resolution-plan.md). The do
 
 ## Next step
 
-A15 is on `main` (PR #64). Next after A13: Wave 4a A20 (`fix/a11y-focus-visible`, #57). Do not put #64 on the A13 row.
+A13 is on `main` (PR #65). Next after A20: Wave 4b A12 (`fix/a11y-headings`, #49). Do not put #65 on the A20 row.

--- a/public/components/toolbar.css
+++ b/public/components/toolbar.css
@@ -27,6 +27,15 @@
   transition: all 0.2s ease;
 }
 
+/* Same two-tone keyboard ring as .matching-selection-area / .mcq-option. */
+.global-toolbar-tool:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow:
+    0 0 0 2px var(--Colors-Base-Neutral-1450),
+    0 0 0 4px var(--Colors-Base-Neutral-00);
+}
+
 .global-toolbar-tool:hover:not(:disabled) {
   background: transparent;
   opacity: 0.7;

--- a/public/modules/fib.css
+++ b/public/modules/fib.css
@@ -170,6 +170,15 @@
   width: 96px;
 }
 
+/* Same two-tone keyboard ring as .matching-selection-area / .mcq-option. */
+.blank:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow:
+    0 0 0 2px var(--Colors-Base-Neutral-1450),
+    0 0 0 4px var(--Colors-Base-Neutral-00);
+}
+
 .blank:hover,
 .blank.dropdown-open {
   border-radius: var(--UI-Radius-radius-s);

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -100,6 +100,27 @@ test('A13: toolbar is appended inside main; no skip link or new toolbar name', (
   assert.doesNotMatch(html, /skip[- ]link/i);
 });
 
+test('A20: FIB blanks and toolbar tools use the two-tone focus-visible ring', () => {
+  function focusVisibleRule(css, selector) {
+    const re = new RegExp(
+      selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ':focus-visible\\s*\\{[^}]+\\}'
+    );
+    const m = css.match(re);
+    assert.ok(m, `${selector}:focus-visible rule exists`);
+    assert.match(m[0], /outline:\s*2px solid transparent/);
+    assert.match(m[0], /--Colors-Base-Neutral-1450/);
+    assert.match(m[0], /--Colors-Base-Neutral-00/);
+    return m[0];
+  }
+
+  focusVisibleRule(read('public/modules/fib.css'), '.blank');
+  focusVisibleRule(read('public/components/toolbar.css'), '.global-toolbar-tool');
+
+  const matching = read('public/modules/matching.css');
+  assert.match(matching, /\.matching-selection-area:focus\s*\{/);
+  assert.doesNotMatch(matching, /\.matching-selection-area:focus-visible/);
+});
+
 test('A1 characterization: learner document has lang and a main landmark', () => {
   const html = read('public/index.html');
   assert.match(html, /<html lang="en">/);


### PR DESCRIPTION
## Summary
Closes #57. FIB blanks and toolbar tools use the same two-tone keyboard ring as Matching and MCQ, so the indicator is not UA-outline-only. Matching still uses `:focus` on purpose.

Also records A13 as closed (PR #65) on the issue map. That number is not on the A20 row.

## Changes
`.blank:focus-visible` and `.global-toolbar-tool:focus-visible` get the Neutral-1450 / Neutral-00 stacked ring and a transparent outline for forced-colors. These controls are not scripted-focus widgets, so `:focus-visible` is the right trigger.

## Test plan
- [x] `npm test` — A20 characterization
- [x] `fib-simple.md`: both rules are in the live CSSOM with the two-tone tokens; Matching `:focus` unchanged
- [x] Keyboard Tab in light and dark: ring on a blank and on Clear All
- [x] Host iframe (`needs-manual-verify`)
