### PR TITLE
A11y | Restore activity headings

### DIFF
--- a/a11y-audits/8-13-26/wave-4-plan.md
+++ b/a11y-audits/8-13-26/wave-4-plan.md
@@ -4,7 +4,7 @@
 **Program:** [program-plan.md](./program-plan.md)  
 **Critical / serious:** [resolution-plan.md](./resolution-plan.md) (A1–A11, D1–D2 on `main`)  
 **Standard:** WCAG 2.2 AA  
-**Status:** Product calls P8–P15 confirmed. Issues filed. A13 on `main` (PR #65). Executing Wave 4a A20.
+**Status:** Product calls P8–P15 confirmed. Issues filed. A20 on `main` (PR #66). Executing Wave 4b A12.
 
 In scope: **A12–A20, D3**, and leftover axe **A21**.  
 Out of this plan: A1–A11, D1, D2. Do not reopen them. Do not retune A7 Learn-Practice choice tokens. Question editor stays out (internal-only).
@@ -32,6 +32,7 @@ Out of this plan: A1–A11, D1, D2. Do not reopen them. Do not retune A7 Learn-P
 | A18 | #63 | MCQ fieldset named from question UI |
 | A15 | #64 | Text Input Next button mounted |
 | A13 | #65 | Toolbar inside `<main>` |
+| A20 | #66 | Designed focus ring on FIB blanks and toolbar tools |
 | D3 | DS #33 → app #61 | Divider line token (Neutral-800), ≥3:1 vs panes |
 
 Unrelated merges on the same timeline: clipboard in iframes (#43), Sort heading font (#45). Not audit IDs.
@@ -261,7 +262,7 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 | A17 | #54 | 4a | #60 | Closed (PR #60) |
 | A18 | #55 | 4a | #63 | Closed (PR #63) |
 | A19 | #56 | 4b | | Open |
-| A20 | #57 | 4a | | Open |
+| A20 | #57 | 4a | #66 | Closed (PR #66) |
 | A21 | #58 | 4b | | Open |
 | D3 | [DS #32](https://github.com/CodeSignal/learn_bespoke-design-system/issues/32) | 4 ∥ | #61 | Closed (PR #61) |
 | DS bump D3 | #59 | after D3 | #61 | Closed (PR #61) |
@@ -281,4 +282,4 @@ Critical/serious rows stay in [resolution-plan.md](./resolution-plan.md). The do
 
 ## Next step
 
-A13 is on `main` (PR #65). Next after A20: Wave 4b A12 (`fix/a11y-headings`, #49). Do not put #65 on the A20 row.
+A20 is on `main` (PR #66). Next: Wave 4b A12 (`fix/a11y-headings`, #49). Do not put #66 on the A12 row.

--- a/public/modules/matching.js
+++ b/public/modules/matching.js
@@ -1,5 +1,5 @@
 import HorizontalCards from '../design-system/components/horizontal-cards/horizontal-cards.js';
-import { renderMath } from '../utils/katex-render.js';
+import { ACTIVITY_TYPE_NAME, mountActivityHeading } from '../utils/activity-heading.js';
 import toolbar from '../components/toolbar.js';
 
 export function initMatching({
@@ -30,19 +30,12 @@ export function initMatching({
   const elMatchingCardsContainer = document.getElementById('matching-cards-container');
   const elMatchingChoices = document.getElementById('matching-choices');
 
-  const matchInstr = matching.heading;
-  if (matchInstr && (matchInstr.html || matchInstr.markdown)) {
-    const instrEl = document.createElement('div');
-    instrEl.className =
-      'text-input-heading box non-interactive input-group text-input-question-text body-large';
-    if (matchInstr.html) {
-      instrEl.innerHTML = matchInstr.html;
-    } else {
-      instrEl.textContent = matchInstr.markdown;
-    }
-    renderMath(instrEl);
-    elMatching.insertBefore(instrEl, elMatching.firstChild);
-  }
+  mountActivityHeading({
+    parent: elMatching,
+    heading: matching.heading,
+    fallback: ACTIVITY_TYPE_NAME.matching,
+    before: elMatching.firstChild
+  });
 
   // Selection state - initialize with persisted answers if available
   const selectedByItemIdx = matching.items.map((_, idx) => {

--- a/public/modules/matrix.js
+++ b/public/modules/matrix.js
@@ -1,6 +1,7 @@
 import toolbar from '../components/toolbar.js';
 import { detectQuoteBlockquotes } from '../design-system/typography/typography.js';
 import { renderMath } from '../utils/katex-render.js';
+import { ACTIVITY_TYPE_NAME, mountActivityHeading } from '../utils/activity-heading.js';
 import {
   clearControlInvalid,
   ensureErrorText,
@@ -70,19 +71,12 @@ export function initMatrix({
   const elTbody = elContainer.querySelector('#matrix-tbody');
   const elExplainHost = elContainer.querySelector('#matrix-explain-host');
 
-  const matrixHeading = matrix.heading;
-  if (matrixHeading && (matrixHeading.html || matrixHeading.markdown)) {
-    const headingEl = document.createElement('div');
-    headingEl.className =
-      'text-input-heading box non-interactive input-group text-input-question-text body-large markdown-content';
-    if (matrixHeading.html) {
-      headingEl.innerHTML = matrixHeading.html;
-    } else {
-      headingEl.textContent = matrixHeading.markdown;
-    }
-    renderMath(headingEl);
-    elQuestion.insertAdjacentElement('beforebegin', headingEl);
-  }
+  mountActivityHeading({
+    parent: elQuestion.parentNode,
+    heading: matrix.heading,
+    fallback: ACTIVITY_TYPE_NAME.matrix,
+    before: elQuestion
+  });
 
   if (activity.questionHtml) {
     elQuestion.classList.add('markdown-content');

--- a/public/modules/mcq.js
+++ b/public/modules/mcq.js
@@ -1,6 +1,7 @@
 import toolbar from '../components/toolbar.js';
 import { detectQuoteBlockquotes } from '../design-system/typography/typography.js';
 import { renderMath } from '../utils/katex-render.js';
+import { ACTIVITY_TYPE_NAME, mountActivityHeading } from '../utils/activity-heading.js';
 import {
   clearControlInvalid,
   ensureErrorText,
@@ -60,20 +61,13 @@ export function initMcq({
     });
   }
 
-  // Optional heading (shared pattern with Text Input)
   const hasHeading = mcq.heading && (mcq.heading.html || mcq.heading.markdown);
-  if (hasHeading) {
-    const headingEl = document.createElement('div');
-    headingEl.className =
-      'text-input-heading box non-interactive input-group text-input-question-text body-large markdown-content';
-    if (mcq.heading.html) {
-      headingEl.innerHTML = mcq.heading.html;
-    } else {
-      headingEl.textContent = mcq.heading.markdown;
-    }
-    renderMath(headingEl);
-    elQuestions.appendChild(headingEl);
-  }
+  mountActivityHeading({
+    parent: hasHeading ? elQuestions : elMcq,
+    heading: mcq.heading,
+    fallback: ACTIVITY_TYPE_NAME.mcq,
+    before: hasHeading ? null : elQuestions
+  });
 
   // Track selected answers per question
   const selectedAnswers = {};

--- a/public/modules/sort.js
+++ b/public/modules/sort.js
@@ -1,4 +1,5 @@
 import { renderMath } from '../utils/katex-render.js';
+import { ACTIVITY_TYPE_NAME, mountActivityHeading } from '../utils/activity-heading.js';
 import toolbar from '../components/toolbar.js';
 import {
   INCORRECT_ANSWER_TEXT,
@@ -58,9 +59,16 @@ export function initSort({
     </div>
   `;
 
+  const elRoot = elContainer.querySelector('#categorization');
   const elCategories = elContainer.querySelector('#categorization-categories');
   const elTray = elContainer.querySelector('#categorization-tray');
   const elQuestion = elContainer.querySelector('.categorization-question');
+
+  mountActivityHeading({
+    parent: elRoot,
+    fallback: ACTIVITY_TYPE_NAME.sort,
+    before: elRoot.firstChild
+  });
 
   // Optional practice question / prompt.
   if (activity.questionHtml || activity.question) {

--- a/public/modules/text-input.js
+++ b/public/modules/text-input.js
@@ -1,5 +1,6 @@
 import toolbar from '../components/toolbar.js';
 import { renderMath } from '../utils/katex-render.js';
+import { ACTIVITY_TYPE_NAME, mountActivityHeading } from '../utils/activity-heading.js';
 import {
   clearControlInvalid,
   ensureErrorText,
@@ -297,19 +298,13 @@ export function initTextInput({
     });
   }
   
-  // Optional heading section (instructions for the questions)
   const hasHeading = textInput.heading && (textInput.heading.html || textInput.heading.markdown);
-  if (hasHeading) {
-    const headingEl = document.createElement('div');
-    headingEl.className = 'text-input-heading box non-interactive input-group text-input-question-text body-large markdown-content';
-    if (textInput.heading.html) {
-      headingEl.innerHTML = textInput.heading.html;
-    } else {
-      headingEl.textContent = textInput.heading.markdown;
-    }
-    renderMath(headingEl);
-    elQuestions.appendChild(headingEl);
-  }
+  mountActivityHeading({
+    parent: hasHeading ? elQuestions : elQuestions.parentNode,
+    heading: textInput.heading,
+    fallback: ACTIVITY_TYPE_NAME.textInput,
+    before: hasHeading ? null : elQuestions
+  });
 
   // Render all questions
   const hasMultipleQuestions = textInput.questions.length > 1;

--- a/public/styles.css
+++ b/public/styles.css
@@ -122,6 +122,11 @@ h1, h2, h3, h4, h5, h6 {
   color: var(--Colors-Text-Body-Strong);
 }
 
+.activity-type-heading {
+  color: var(--Colors-Text-Body-Strong);
+  line-height: 1.35;
+}
+
 h4 {
   font-size: 1.1em;
   line-height: 1.35;

--- a/public/utils/activity-heading.js
+++ b/public/utils/activity-heading.js
@@ -1,0 +1,46 @@
+import { renderMath } from './katex-render.js';
+
+export const ACTIVITY_TYPE_NAME = {
+  fib: 'Fill in the blanks',
+  matching: 'Matching',
+  matrix: 'Matrix',
+  mcq: 'Multiple Choice',
+  textInput: 'Text Input',
+  sort: 'Sort into Boxes'
+};
+
+const AUTHORED_HEADING_CLASS =
+  'text-input-heading box non-interactive input-group text-input-question-text body-large markdown-content';
+
+function hasAuthoredHeading(heading) {
+  return !!(heading && (heading.html || heading.markdown));
+}
+
+function fillAuthoredHeading(el, heading) {
+  if (heading.html) {
+    el.innerHTML = heading.html;
+    if (el.children.length === 1 && el.firstElementChild.tagName === 'P') {
+      el.replaceChildren(...el.firstElementChild.childNodes);
+    }
+  } else {
+    el.textContent = heading.markdown;
+  }
+  renderMath(el);
+}
+
+/**
+ * Mount one activity `h2`. Authored `heading` wins; otherwise the P10 type name.
+ */
+export function mountActivityHeading({ parent, heading, fallback, className = AUTHORED_HEADING_CLASS, before = null }) {
+  const el = document.createElement('h2');
+  if (hasAuthoredHeading(heading)) {
+    el.className = className;
+    fillAuthoredHeading(el, heading);
+  } else {
+    el.className = 'activity-type-heading heading-xsmall';
+    el.textContent = fallback;
+  }
+  if (before) parent.insertBefore(el, before);
+  else parent.appendChild(el);
+  return el;
+}

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -100,6 +100,52 @@ test('A13: toolbar is appended inside main; no skip link or new toolbar name', (
   assert.doesNotMatch(html, /skip[- ]link/i);
 });
 
+test('A12: every in-scope activity exposes an h2; authored heading wins', () => {
+  const helper = read('public/utils/activity-heading.js');
+  assert.match(helper, /createElement\('h2'\)/);
+  assert.match(helper, /Fill in the blanks/);
+  assert.match(helper, /Matching/);
+  assert.match(helper, /Matrix/);
+  assert.match(helper, /Multiple Choice/);
+  assert.match(helper, /Text Input/);
+  assert.match(helper, /Sort into Boxes/);
+  assert.doesNotMatch(helper, /skip[- ]link/i);
+
+  const modules = [
+    ['mcq.js', /ACTIVITY_TYPE_NAME\.mcq/],
+    ['matrix.js', /ACTIVITY_TYPE_NAME\.matrix/],
+    ['text-input.js', /ACTIVITY_TYPE_NAME\.textInput/],
+    ['matching.js', /ACTIVITY_TYPE_NAME\.matching/],
+    ['sort.js', /ACTIVITY_TYPE_NAME\.sort/]
+  ];
+  for (const [file, fallback] of modules) {
+    const src = read(`public/modules/${file}`);
+    assert.match(src, /mountActivityHeading/, `${file} mounts an activity heading`);
+    assert.match(src, fallback, `${file} uses the P10 type-name fallback`);
+    assert.doesNotMatch(src, /skip[- ]link/i);
+  }
+
+  const sort = read('public/modules/sort.js');
+  assert.match(
+    sort,
+    /Click or drag the items onto the cards above/,
+    'A12 does not change the A14 instruction sentence'
+  );
+
+  const fib = read('public/modules/fib.js');
+  assert.match(fib, /<h2 class="fib-heading heading-xsmall">/);
+  assert.match(fib, /elFibHeading\.textContent = 'Fill in the blanks'/);
+  assert.match(
+    fib,
+    /createElement\('div'\)/,
+    'FIB authored heading stays a div; the type-name h2 is the rotor entry'
+  );
+  assert.doesNotMatch(fib, /mountActivityHeading/);
+
+  const html = read('public/index.html');
+  assert.doesNotMatch(html, /skip[- ]link/i);
+});
+
 test('A20: FIB blanks and toolbar tools use the two-tone focus-visible ring', () => {
   function focusVisibleRule(css, selector) {
     const re = new RegExp(


### PR DESCRIPTION
## Summary
Closes #49. Every in-scope activity exposes an `h2`, so AT can find a heading on MCQ, Matrix, Text Input, Matching, and Sort as well as FIB.

Authored `heading` is a real heading when present. If the activity has none, the type name from P10 is used: Fill in the blanks, Matching, Matrix, Multiple Choice, Text Input, Sort into Boxes. FIB still mounts `h2.fib-heading` "Fill in the blanks".

Also records A20 as closed (PR #66) on the issue map. That number is not on the A12 row.

## Changes
A small helper mounts one `h2` per activity. Authored markdown keeps the existing instruction-card classes. A single wrapping `<p>` from `marked` is unwrapped so the heading is valid HTML.

Type-name fallbacks use `heading-xsmall`, same level as FIB. Sort only gets the fallback; the parser has no authored heading. The A14 click-or-drag sentence is unchanged. No skip link.

Look at `public/utils/activity-heading.js` and the mount calls in MCQ, Matrix, Text Input, Matching, and Sort. FIB is left as it is.

## Test plan
- [x] `npm test` — A12 characterization
- [x] `/play` headings: MCQ "Multiple Choice", Matrix "Matrix", Text Input simple "Text Input", Text Input advanced uses the authored sentence, Matching "Matching", Sort "Sort into Boxes", FIB "Fill in the blanks"
- [x] Sort click-to-place still works; instruction copy unchanged
- [x] `PORT=3010 A11Y_BASE_URL=http://127.0.0.1:3010 SIM_PORT=8081 SIM_ORIGIN=http://127.0.0.1:8081 npm run a11y:ci` — baseline stays `color-contrast` 1
- [ ] VoiceOver / NVDA heading rotor (`needs-manual-verify`)
