### PR TITLE
A11y | Mention the Sort keyboard path

### DIFF
--- a/a11y-audits/8-13-26/wave-4-plan.md
+++ b/a11y-audits/8-13-26/wave-4-plan.md
@@ -4,7 +4,7 @@
 **Program:** [program-plan.md](./program-plan.md)  
 **Critical / serious:** [resolution-plan.md](./resolution-plan.md) (A1–A11, D1–D2 on `main`)  
 **Standard:** WCAG 2.2 AA  
-**Status:** Product calls P8–P15 confirmed. Issues filed. A20 on `main` (PR #66). Executing Wave 4b A12.
+**Status:** Product calls P8–P15 confirmed. Issues filed. A12 on `main` (PR #67). Executing Wave 4b A14.
 
 In scope: **A12–A20, D3**, and leftover axe **A21**.  
 Out of this plan: A1–A11, D1, D2. Do not reopen them. Do not retune A7 Learn-Practice choice tokens. Question editor stays out (internal-only).
@@ -33,6 +33,7 @@ Out of this plan: A1–A11, D1, D2. Do not reopen them. Do not retune A7 Learn-P
 | A15 | #64 | Text Input Next button mounted |
 | A13 | #65 | Toolbar inside `<main>` |
 | A20 | #66 | Designed focus ring on FIB blanks and toolbar tools |
+| A12 | #67 | Activity `h2`; authored heading or P10 type name |
 | D3 | DS #33 → app #61 | Divider line token (Neutral-800), ≥3:1 vs panes |
 
 Unrelated merges on the same timeline: clipboard in iframes (#43), Sort heading font (#45). Not audit IDs.
@@ -254,7 +255,7 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 | --- | --- | --- | --- | --- |
 | D1 | [DS #29](https://github.com/CodeSignal/learn_bespoke-design-system/issues/29) | 1 ∥ / 3 | #48 | Closed (PR #48) |
 | DS bump D1 | #30 | after D1 | #48 | Closed (PR #48) |
-| A12 | #49 | 4b | | Open |
+| A12 | #49 | 4b | #67 | Closed (PR #67) |
 | A13 | #50 | 4a | #65 | Closed (PR #65) |
 | A14 | #51 | 4b | | Open |
 | A15 | #52 | 4a | #64 | Closed (PR #64) |
@@ -282,4 +283,4 @@ Critical/serious rows stay in [resolution-plan.md](./resolution-plan.md). The do
 
 ## Next step
 
-A20 is on `main` (PR #66). Next: Wave 4b A12 (`fix/a11y-headings`, #49). Do not put #66 on the A12 row.
+A12 is on `main` (PR #67). Next: Wave 4b A14 (`fix/a11y-sort-keyboard-copy`, #51). Do not put #67 on the A14 row.

--- a/public/modules/sort.js
+++ b/public/modules/sort.js
@@ -52,7 +52,7 @@ export function initSort({
       <div class="categorization-categories" id="categorization-categories"></div>
       <div class="categorization-instructions">
         <span class="categorization-instructions-icon" aria-hidden="true">${instructionIconSvg()}</span>
-        <p class="categorization-instructions-text body-xxsmall">Click or drag the items onto the cards above</p>
+        <p class="categorization-instructions-text body-xxsmall">Click or drag the items onto the cards above, or select an item and press Enter on a card.</p>
       </div>
       <p id="sort-validate-error" class="activity-error-text body-small" hidden></p>
       <div class="categorization-tray" id="categorization-tray" role="list" aria-label="Items to sort"></div>

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -128,8 +128,7 @@ test('A12: every in-scope activity exposes an h2; authored heading wins', () => 
   const sort = read('public/modules/sort.js');
   assert.match(
     sort,
-    /Click or drag the items onto the cards above/,
-    'A12 does not change the A14 instruction sentence'
+    /Click or drag the items onto the cards above, or select an item and press Enter on a card\./
   );
 
   const fib = read('public/modules/fib.js');
@@ -324,12 +323,20 @@ test('A7: dark choice default and hover contrast are at least 4.5:1', () => {
   }
 });
 
+test('A14: Sort instructions include the keyboard path', () => {
+  const sortJs = read('public/modules/sort.js');
+  assert.match(
+    sortJs,
+    /Click or drag the items onto the cards above, or select an item and press Enter on a card\./
+  );
+});
+
 test('A8: Sort instructions meet 4.5:1 in light and keep the click-or-drag copy', () => {
   const sortJs = read('public/modules/sort.js');
   assert.match(
     sortJs,
-    /Click or drag the items onto the cards above/,
-    'instruction copy stays put (P8 / A14 is out of this plan)'
+    /Click or drag the items onto the cards above, or select an item and press Enter on a card\./,
+    'instruction copy includes the keyboard path (P11)'
   );
 
   const sortCss = read('public/modules/sort.css');


### PR DESCRIPTION
## Summary
Closes #51. Sort instructions now include the keyboard path that already exists, so 2.5.7 is discoverable (3.3.2).

The line is the confirmed P11 sentence: “Click or drag the items onto the cards above, or select an item and press Enter on a card.”

Also records A12 as closed (PR #67) on the issue map. That number is not on the A14 row.

## Changes
One string in `sort.js`. Click-to-place, the category-head button (Enter/Space), and drag are unchanged. “Drop items here” and the A21 dropzone token are unchanged.

The A8 characterization lock now asserts the P11 sentence. A14 has its own characterization test for the same copy.

## Test plan
- [x] `npm test` — A14 and flipped A8 copy lock
- [x] `/play` `sort-into-boxes.md`: new sentence is visible; click-to-place works; activating the category head places the selected chip; drag still places
- [x] `PORT=3010 A11Y_BASE_URL=http://127.0.0.1:3010 SIM_PORT=8081 SIM_ORIGIN=http://127.0.0.1:8081 npm run a11y:ci` — baseline stays `color-contrast` 1
- [ ] VoiceOver / keyboard pass (`needs-manual-verify`)
