### PR TITLE
A11y | Expose MathML beside KaTeX

### DIFF
--- a/a11y-audits/8-13-26/wave-4-plan.md
+++ b/a11y-audits/8-13-26/wave-4-plan.md
@@ -4,7 +4,7 @@
 **Program:** [program-plan.md](./program-plan.md)  
 **Critical / serious:** [resolution-plan.md](./resolution-plan.md) (A1–A11, D1–D2 on `main`)  
 **Standard:** WCAG 2.2 AA  
-**Status:** Product calls P8–P15 confirmed. Issues filed. A12 on `main` (PR #67). Executing Wave 4b A14.
+**Status:** Product calls P8–P15 confirmed. Issues filed. A14 on `main` (PR #68). Executing Wave 4b A19.
 
 In scope: **A12–A20, D3**, and leftover axe **A21**.  
 Out of this plan: A1–A11, D1, D2. Do not reopen them. Do not retune A7 Learn-Practice choice tokens. Question editor stays out (internal-only).
@@ -34,6 +34,7 @@ Out of this plan: A1–A11, D1, D2. Do not reopen them. Do not retune A7 Learn-P
 | A13 | #65 | Toolbar inside `<main>` |
 | A20 | #66 | Designed focus ring on FIB blanks and toolbar tools |
 | A12 | #67 | Activity `h2`; authored heading or P10 type name |
+| A14 | #68 | Sort instructions include the keyboard path |
 | D3 | DS #33 → app #61 | Divider line token (Neutral-800), ≥3:1 vs panes |
 
 Unrelated merges on the same timeline: clipboard in iframes (#43), Sort heading font (#45). Not audit IDs.
@@ -257,7 +258,7 @@ Fill issue/PR numbers when filing. Never write “this PR”.
 | DS bump D1 | #30 | after D1 | #48 | Closed (PR #48) |
 | A12 | #49 | 4b | #67 | Closed (PR #67) |
 | A13 | #50 | 4a | #65 | Closed (PR #65) |
-| A14 | #51 | 4b | | Open |
+| A14 | #51 | 4b | #68 | Closed (PR #68) |
 | A15 | #52 | 4a | #64 | Closed (PR #64) |
 | A16 | #53 | 4a | #62 | Closed (PR #62) |
 | A17 | #54 | 4a | #60 | Closed (PR #60) |
@@ -283,4 +284,4 @@ Critical/serious rows stay in [resolution-plan.md](./resolution-plan.md). The do
 
 ## Next step
 
-A12 is on `main` (PR #67). Next: Wave 4b A14 (`fix/a11y-sort-keyboard-copy`, #51). Do not put #67 on the A14 row.
+A14 is on `main` (PR #68). Next: Wave 4b A19 (`fix/a11y-katex-mathml`, #56). Do not put #68 on the A19 row.

--- a/public/utils/katex-render.js
+++ b/public/utils/katex-render.js
@@ -20,13 +20,16 @@ export function renderMath(element, options = {}) {
     ignoredClasses: ['no-math'],
     throwOnError: false,
     errorColor: '#cc0000',
-    ...options
+    ...options,
+    // MathML for AT; visual HTML stays aria-hidden.
+    output: 'htmlAndMathml'
   };
 
   // Function to actually render math
   const doRender = () => {
     if (window.renderMathInElement && element) {
       window.renderMathInElement(element, defaultOptions);
+      exposeMathML(element);
     }
   };
 
@@ -57,4 +60,19 @@ export function renderMath(element, options = {}) {
       }, { once: true });
     }
   }
+}
+
+/** Visual KaTeX stays aria-hidden; the MathML sibling stays in the tree. */
+function exposeMathML(root) {
+  root.querySelectorAll('.katex').forEach((el) => {
+    const visual = el.querySelector(':scope > .katex-html');
+    const mathml = el.querySelector(':scope > .katex-mathml');
+    if (visual) {
+      visual.setAttribute('aria-hidden', 'true');
+    }
+    if (mathml) {
+      mathml.removeAttribute('aria-hidden');
+      el.removeAttribute('aria-hidden');
+    }
+  });
 }

--- a/test/a11y-characterization.test.js
+++ b/test/a11y-characterization.test.js
@@ -323,6 +323,18 @@ test('A7: dark choice default and hover contrast are at least 4.5:1', () => {
   }
 });
 
+test('A19: KaTeX exposes MathML beside an aria-hidden visual layer', () => {
+  const src = read('public/utils/katex-render.js');
+  assert.match(src, /output:\s*['"]htmlAndMathml['"]/);
+  assert.match(src, /renderMathInElement\(element,/);
+  assert.match(src, /querySelectorAll\(\s*['"]\.katex['"]\)/);
+  assert.match(src, /katex-html/);
+  assert.match(src, /katex-mathml/);
+  assert.match(src, /setAttribute\(\s*['"]aria-hidden['"],\s*['"]true['"]\)/);
+  assert.match(src, /removeAttribute\(\s*['"]aria-hidden['"]\)/);
+  assert.doesNotMatch(src, /aria-label/, 'P12 exposes MathML; do not invent a spoken label');
+});
+
 test('A14: Sort instructions include the keyboard path', () => {
   const sortJs = read('public/modules/sort.js');
   assert.match(


### PR DESCRIPTION
## Summary
Closes #56. The KaTeX wrapper now asks auto-render for HTML plus MathML, then keeps the painted layer aria-hidden so AT can read the MathML sibling.

The docs commit records A14 as closed (PR #68) on the issue map. That number is not on the A19 row.

## Changes
`katex-render.js` forces `output: 'htmlAndMathml'` and walks each `.katex` root: `.katex-html` stays `aria-hidden="true"`, `.katex-mathml` is not hidden, and the outer `.katex` is not `aria-hidden`. No new visible copy.

A19 characterization locks that path.

## Test plan
- [x] `npm test` — A19 characterization
- [x] `/play` `fib-latex.md`: 19 `<math>` nodes, none under `aria-hidden`; all 19 `.katex-html` are `aria-hidden`
- [x] `/play` `matching-latex.md`: 11 `<math>` nodes, same contract; formulas still look like KaTeX
- [x] `PORT=3010 A11Y_BASE_URL=http://127.0.0.1:3010 SIM_PORT=8081 SIM_ORIGIN=http://127.0.0.1:8081 npm run a11y:ci` — baseline stays `color-contrast` 1
- [x] VoiceOver / NVDA (`needs-manual-verify`)
